### PR TITLE
Issue/409 chart zoom v1

### DIFF
--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -27,6 +27,7 @@ import { theme } from "../../tailwind.config";
 import useGlobalState, { getNext30MinSlot } from "../helpers/globalState";
 import { DELTA_BUCKET, VIEWS } from "../../constant";
 import get from "@auth0/nextjs-auth0/dist/auth0-session/client";
+import { CloseButtonIcon } from "../icons/icons";
 
 const yellow = theme.extend.colors["ocf-yellow"].DEFAULT;
 const orange = theme.extend.colors["ocf-orange"].DEFAULT;
@@ -231,18 +232,27 @@ const RemixLine: React.FC<RemixLineProps> = ({
   return (
     <div style={{ position: "relative", width: "100%", height: "100%" }}>
       {isZoomed && (
-        <div className="pl-16">
+        <div className="flex">
           <button
+            type="button"
+            onClick={handleZoomOut}
+            style={{ position: "relative", top: "0", left: "20" }}
+            className="flex ml-96 mt-5 font-bold items-center p-0.5 text-xl border-ocf-gray-800 text-white bg-ocf-gray-800 hover:bg-ocf-gray-700 focus:z-10 focus:text-white h-auto"
+          >
+            <CloseButtonIcon />
+          </button>
+          {/* <button
             type="button"
             className="btn ml-3 update text-sm bg-ocf-gray-600 hover:bg-ocf-yellow-500 text-black py-.5 px-1 mr-1 rounded inline-flex items-center"
             onClick={handleZoomOut}
           >
             Reset
-          </button>
+          </button> */}
         </div>
       )}
       <ResponsiveContainer>
         <ComposedChart
+          className="select-none"
           width={500}
           height={400}
           data={isZoomed ? filteredPreppedData : preppedData}
@@ -307,6 +317,7 @@ const RemixLine: React.FC<RemixLineProps> = ({
             interval={view === VIEWS.SOLAR_SITES ? undefined : 11}
           />
           <XAxis
+            className="select-none"
             dataKey="formattedDate"
             xAxisId={"x-axis-2"}
             tickFormatter={prettyPrintChartAxisLabelDate}

--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -153,10 +153,8 @@ const RemixLine: React.FC<RemixLineProps> = ({
   const [zoomArea, setZoomArea] = useState(defaultZoom);
   const [isZooming, setIsZooming] = useState(false);
   const [isZoomed, setIsZoomed] = useState(false);
-  const [xAxisDomain, setXAxisDomain] = useState([0, 0]);
-  const [yAxisBoundary, setYAxisBoundary] = useState("");
-  const [refAreaLeft, setRefAreaLeft] = React.useState("");
-  const [refAreaRight, setRefAreaRight] = React.useState("");
+  // const [refAreaLeft, setRefAreaLeft] = React.useState("");
+  // const [refAreaRight, setRefAreaRight] = React.useState("");
 
   fourHoursFromNow.setHours(fourHoursFromNow.getHours() + 4);
 
@@ -194,15 +192,11 @@ const RemixLine: React.FC<RemixLineProps> = ({
     .filter((n) => typeof n === "number")
     .sort((a, b) => Number(a) - Number(b))[0];
 
-  const yZoomMax = filteredData
-    .map((d) => d.PROBABILISTIC_UPPER_BOUND)
-    .filter((n) => typeof n === "number")
-    .sort((a, b) => Number(b) - Number(a))[0];
-  console.log("yZoomMax", yZoomMax);
   // Take the max absolute value of the delta min and max as the y-axis max
   const deltaYMax =
     deltaYMaxOverride ||
     getRoundedTickBoundary(Math.max(Number(deltaMax), 0 - Number(deltaMin)) || 0, deltaMaxTicks);
+
   const roundTickMax = deltaYMax % 1000 === 0;
   const isGSP = !!deltaYMaxOverride && deltaYMaxOverride < 1000;
   const now = new Date();
@@ -219,6 +213,16 @@ const RemixLine: React.FC<RemixLineProps> = ({
   const showZoomArea = isZooming && zoomArea.x1 && zoomArea.x2 && zoomArea.y1 && zoomArea.y2;
 
   //get Y axis boundary
+
+  const zoomMax = filteredData
+    .map((d) => d.PROBABILISTIC_UPPER_BOUND)
+    .filter((n) => typeof n === "number")
+    .sort((a, b) => Number(b) - Number(a))[0];
+
+  const zoomMaxTickBoundaries = [
+    1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 11000, 12000
+  ];
+  const zoomYMax = getRoundedTickBoundary(Math.max(Number(zoomMax), 0), zoomMaxTickBoundaries);
 
   //reset zoom state
   function handleZoomOut() {
@@ -267,7 +271,6 @@ const RemixLine: React.FC<RemixLineProps> = ({
             if (xValue) {
               setZoomArea({ x1: xValue, x2: xValue, y1: yValue, y2: yValue });
               console.log("Mouse down zoomArea", zoomArea.x1, zoomArea.x2);
-              setRefAreaLeft(xValue);
             }
           }}
           onMouseMove={(e?: { activeLabel?: string; chartY?: number | undefined }) => {
@@ -276,7 +279,6 @@ const RemixLine: React.FC<RemixLineProps> = ({
               let yValue = e?.chartY;
               console.log("Mouse move zoomArea", zoomArea.x1, zoomArea.x2);
               setZoomArea((zoom) => ({ ...zoom, x2: xValue || "", y2: yValue || "" }));
-              refAreaLeft && setRefAreaRight(e?.activeLabel || "");
             }
           }}
           onMouseUp={(e?: { activeLabel?: string; yMaxZoom?: number }) => {
@@ -285,8 +287,6 @@ const RemixLine: React.FC<RemixLineProps> = ({
               if (zoomArea.x1 == zoomArea.x2) {
                 console.log("Mouse up");
                 setZoomArea(defaultZoom);
-                setRefAreaLeft("");
-                setRefAreaRight("");
               } else {
                 setIsZoomed(true);
                 let { x1, x2 } = zoomArea;
@@ -358,7 +358,7 @@ const RemixLine: React.FC<RemixLineProps> = ({
             yAxisId={"y-axis"}
             tick={{ fill: "white", style: { fontSize: "12px" } }}
             tickLine={false}
-            domain={isZoomed ? [0, Number(yZoomMax) + 100] : [0, yMax]}
+            domain={isZoomed ? [0, Number(zoomYMax)] : [0, yMax]}
             label={{
               value: view === VIEWS.SOLAR_SITES ? "Generation (KW)" : "Generation (MW)",
               angle: 270,

--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -27,7 +27,7 @@ import { theme } from "../../tailwind.config";
 import useGlobalState, { getNext30MinSlot } from "../helpers/globalState";
 import { DELTA_BUCKET, VIEWS } from "../../constant";
 import get from "@auth0/nextjs-auth0/dist/auth0-session/client";
-import { CloseButtonIcon } from "../icons/icons";
+import { CloseButtonIcon, CloseButtonIconForZoom } from "../icons/icons";
 
 const yellow = theme.extend.colors["ocf-yellow"].DEFAULT;
 const orange = theme.extend.colors["ocf-orange"].DEFAULT;
@@ -232,22 +232,20 @@ const RemixLine: React.FC<RemixLineProps> = ({
   return (
     <div style={{ position: "relative", width: "100%", height: "100%" }}>
       {isZoomed && (
-        <div className="flex">
+        //put button at top right corner of chart and change location for delta view
+        <div
+          className={
+            deltaView ? `absolute top-5 right-16 mr-3 z-10` : `absolute top-5 right-4 z-10`
+          }
+        >
           <button
             type="button"
             onClick={handleZoomOut}
             style={{ position: "relative", top: "0", left: "20" }}
-            className="flex ml-96 mt-5 font-bold items-center p-0.5 text-xl border-ocf-gray-800 text-white bg-ocf-gray-800 hover:bg-ocf-gray-700 focus:z-10 focus:text-white h-auto"
+            className="flex font-bold items-center p-0.5 border-ocf-gray-800 text-white bg-ocf-gray-800 hover:bg-ocf-gray-700 focus:z-10 focus:text-white h-auto"
           >
-            <CloseButtonIcon />
+            <CloseButtonIconForZoom />
           </button>
-          {/* <button
-            type="button"
-            className="btn ml-3 update text-sm bg-ocf-gray-600 hover:bg-ocf-yellow-500 text-black py-.5 px-1 mr-1 rounded inline-flex items-center"
-            onClick={handleZoomOut}
-          >
-            Reset
-          </button> */}
         </div>
       )}
       <ResponsiveContainer>

--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -28,6 +28,7 @@ import useGlobalState, { getNext30MinSlot } from "../helpers/globalState";
 import { DELTA_BUCKET, VIEWS } from "../../constant";
 import get from "@auth0/nextjs-auth0/dist/auth0-session/client";
 import { CloseButtonIcon, CloseButtonIconForZoom } from "../icons/icons";
+import { getZoomYMax } from "../helpers/chartUtils";
 
 const yellow = theme.extend.colors["ocf-yellow"].DEFAULT;
 const orange = theme.extend.colors["ocf-orange"].DEFAULT;
@@ -215,10 +216,7 @@ const RemixLine: React.FC<RemixLineProps> = ({
     9000, 10000, 11000, 12000
   ];
 
-  let zoomYMax = filteredPreppedData
-    .map((d) => d.PROBABILISTIC_UPPER_BOUND)
-    .filter((n) => typeof n === "number")
-    .sort((a, b) => Number(b) - Number(a))[0];
+  let zoomYMax = getZoomYMax(filteredPreppedData);
 
   zoomYMax = getRoundedTickBoundary(zoomYMax || 0, yMaxZoom_Levels);
 
@@ -232,7 +230,6 @@ const RemixLine: React.FC<RemixLineProps> = ({
   return (
     <div style={{ position: "relative", width: "100%", height: "100%" }}>
       {isZoomed && (
-        //put button at top right corner of chart and change location for delta view
         <div
           className={
             deltaView ? `absolute top-5 right-16 mr-3 z-10` : `absolute top-5 right-4 z-10`
@@ -358,7 +355,7 @@ const RemixLine: React.FC<RemixLineProps> = ({
             yAxisId={"y-axis"}
             tick={{ fill: "white", style: { fontSize: "12px" } }}
             tickLine={false}
-            domain={isZoomed ? [0, Number(zoomYMax + zoomYMax * 0.2)] : [0, yMax]}
+            domain={isZoomed ? [0, Number(zoomYMax + zoomYMax * 0.1)] : [0, yMax]}
             label={{
               value: view === VIEWS.SOLAR_SITES ? "Generation (KW)" : "Generation (MW)",
               angle: 270,

--- a/apps/nowcasting-app/components/helpers/chartUtils.ts
+++ b/apps/nowcasting-app/components/helpers/chartUtils.ts
@@ -1,0 +1,30 @@
+// tools for the chart
+import { ChartData } from "../charts/remix-line";
+// get the zoomYMax for either sites or national view
+export const getZoomYMax = (filteredPreppedData: ChartData[]) => {
+  // if no probabilistic max value, get the max between the generation and the forecast as the zoomYMax
+  if (!filteredPreppedData.some((d) => d.PROBABILISTIC_UPPER_BOUND)) {
+    console.log(filteredPreppedData);
+    let genMax =
+      filteredPreppedData
+        .map((d) => d.GENERATION_UPDATED || d.GENERATION)
+        .filter((n) => typeof n === "number")
+        .sort((a, b) => Number(b) - Number(a))[0] || 0;
+    console.log("genMax", genMax);
+    let forecastMax =
+      filteredPreppedData
+        .map((d) => d.PAST_FORECAST || d.FORECAST)
+        .sort((a, b) => Number(b) - Number(a))[0] || 0;
+    console.log("forecastMax", forecastMax);
+    let calculatedYMax = Math.max(genMax, forecastMax);
+    console.log("calculatedYMax no probabilistic", calculatedYMax);
+    return calculatedYMax;
+  } else {
+    let calculatedYMax = filteredPreppedData
+      .map((d) => d.PROBABILISTIC_UPPER_BOUND || d.GENERATION)
+      .filter((n) => typeof n === "number")
+      .sort((a, b) => Number(b) - Number(a))[0];
+    console.log("calculatedYMax with probabilistic", calculatedYMax);
+    return calculatedYMax;
+  }
+};

--- a/apps/nowcasting-app/components/icons/icons.tsx
+++ b/apps/nowcasting-app/components/icons/icons.tsx
@@ -51,6 +51,22 @@ export const CloseButtonIcon: React.FC<IconProps> = ({ className }) => (
   </svg>
 );
 
+export const CloseButtonIconForZoom: React.FC<IconProps> = ({ className }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    version="1.1"
+    width="1.5rem"
+    height="1.5rem"
+    viewBox="0 0 24 24"
+  >
+    <path
+      strokeWidth={2}
+      d="M20.030 5.030l-1.061-1.061-6.97 6.97-6.97-6.97-1.061 1.061 6.97 6.97-6.97 6.97 1.061 1.061 6.97-6.97 6.97 6.97 1.061-1.061-6.97-6.97 6.97-6.97z"
+      fill="white"
+    />
+  </svg>
+);
+
 export const ClockIcon: React.FC<IconProps> = ({ className }) => (
   <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path


### PR DESCRIPTION
#Pull Request

## Description

This adds the zoom feature to the chart.  Currently you can highlight the chart you want to inspect and the main y-axis domain is adjusted based on the maximum y value in the selected set of data. 

The Recharts library allows you to highlight a reference area and then redraw the chart boundaries. 

I'm wondering if the `RemixLine` could use another prop that would be the `zoomYMax` of the chart when a chart is in a zoomed state. 

Here are a few screenshots of the feature. 

<img width="512" alt="Screenshot 2023-12-18 at 21 20 17" src="https://github.com/openclimatefix/nowcasting/assets/86949265/67157fa4-f2aa-42fc-87a1-c35860034de3">

<img width="272" alt="Screenshot 2023-12-18 at 21 25 13" src="https://github.com/openclimatefix/nowcasting/assets/86949265/a38f0fa2-fd19-4591-a51c-33bbcfa6fca4">

<img width="531" alt="Screenshot 2023-12-18 at 21 21 02" src="https://github.com/openclimatefix/nowcasting/assets/86949265/dc949646-9e89-4289-bed5-3d8abebd5e98">

Fixes #409

## How Has This Been Tested?

I ran the code locally. 


## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
