### PR TITLE
feat: incresed MAX_NATIONAL_GENERATION_MW and dynamic yMax value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 build/**
 dist/**
 .next/**
+.env

--- a/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
+++ b/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
@@ -67,6 +67,29 @@ const PvRemixChart: FC<{
     timeTrigger: selectedTime
   });
 
+  const yMax = useMemo(() => {
+    if (!chartData || chartData.length === 0) {
+      return MAX_NATIONAL_GENERATION_MW; // Default max value
+    }
+
+    const maxDataValue = Math.max(
+      0,
+      ...chartData.flatMap((dataPoint) =>
+        Object.entries(dataPoint)
+          .filter(
+            ([key, value]) =>
+              typeof value === "number" && key !== "formattedDate" && !key.includes("TIME")
+          )
+          .map(([_, value]) => value as number)
+      )
+    );
+
+    const buffer = 1000; // This buffer is added to the max value to ensure the chart is not too close to the top
+    const roundedMax = Math.ceil((maxDataValue + buffer) / 1000) * 1000;
+
+    return Math.max(MAX_NATIONAL_GENERATION_MW, roundedMax);
+  }, [chartData]);
+
   if (
     nationalForecastError ||
     pvRealDayInError ||
@@ -105,7 +128,7 @@ const PvRemixChart: FC<{
               timeOfInterest={selectedTime}
               setTimeOfInterest={setSelectedTime}
               data={chartData}
-              yMax={MAX_NATIONAL_GENERATION_MW}
+              yMax={yMax}
               visibleLines={visibleLines}
             />
           </div>

--- a/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
+++ b/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
@@ -69,7 +69,7 @@ const PvRemixChart: FC<{
   });
 
   const yMax = useMemo(() => {
-    return calculateChartYMax(chartData);
+    return calculateChartYMax(chartData, MAX_NATIONAL_GENERATION_MW);
   }, [chartData]);
 
   if (
@@ -110,7 +110,7 @@ const PvRemixChart: FC<{
               timeOfInterest={selectedTime}
               setTimeOfInterest={setSelectedTime}
               data={chartData}
-              yMax={Math.max(yMax, MAX_NATIONAL_GENERATION_MW)}
+              yMax={yMax}
               visibleLines={visibleLines}
             />
           </div>

--- a/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
+++ b/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
@@ -13,6 +13,7 @@ import { CombinedData, CombinedErrors } from "../types";
 import { ChartLegend } from "./ChartLegend";
 import DataLoadingChartStatus from "./DataLoadingChartStatus";
 import { calculateChartYMax } from "../helpers/utils";
+import { getTicks } from "../helpers/chartUtils";
 
 const PvRemixChart: FC<{
   combinedData: CombinedData;
@@ -112,6 +113,7 @@ const PvRemixChart: FC<{
               data={chartData}
               yMax={yMax}
               visibleLines={visibleLines}
+              yTicks={getTicks(yMax, [])}
             />
           </div>
         </div>

--- a/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
+++ b/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
@@ -12,6 +12,7 @@ import useHotKeyControlChart from "../hooks/use-hot-key-control-chart";
 import { CombinedData, CombinedErrors } from "../types";
 import { ChartLegend } from "./ChartLegend";
 import DataLoadingChartStatus from "./DataLoadingChartStatus";
+import { calculateChartYMax } from "../helpers/utils";
 
 const PvRemixChart: FC<{
   combinedData: CombinedData;
@@ -68,26 +69,7 @@ const PvRemixChart: FC<{
   });
 
   const yMax = useMemo(() => {
-    if (!chartData || chartData.length === 0) {
-      return MAX_NATIONAL_GENERATION_MW; // Default max value
-    }
-
-    const maxDataValue = Math.max(
-      0,
-      ...chartData.flatMap((dataPoint) =>
-        Object.entries(dataPoint)
-          .filter(
-            ([key, value]) =>
-              typeof value === "number" && key !== "formattedDate" && !key.includes("TIME")
-          )
-          .map(([_, value]) => value as number)
-      )
-    );
-
-    const buffer = 1000; // This buffer is added to the max value to ensure the chart is not too close to the top
-    const roundedMax = Math.ceil((maxDataValue + buffer) / 1000) * 1000;
-
-    return Math.max(MAX_NATIONAL_GENERATION_MW, roundedMax);
+    return calculateChartYMax(chartData);
   }, [chartData]);
 
   if (
@@ -128,7 +110,7 @@ const PvRemixChart: FC<{
               timeOfInterest={selectedTime}
               setTimeOfInterest={setSelectedTime}
               data={chartData}
-              yMax={yMax}
+              yMax={Math.max(yMax, MAX_NATIONAL_GENERATION_MW)}
               visibleLines={visibleLines}
             />
           </div>

--- a/apps/nowcasting-app/components/helpers/chartUtils.test.ts
+++ b/apps/nowcasting-app/components/helpers/chartUtils.test.ts
@@ -1,0 +1,56 @@
+import { getTicks } from "./chartUtils";
+import { describe, expect, it } from "@jest/globals";
+
+describe("getTicks", () => {
+  it("should return ticks for a yMax divisible by 3", () => {
+    const ticks = getTicks(300, []);
+    expect(ticks).toEqual([100, 200, 300]);
+  });
+
+  it("should return ticks for a yMax divisible by 4", () => {
+    const ticks = getTicks(400, []);
+    expect(ticks).toEqual([100, 200, 300, 400]);
+  });
+
+  it("should return ticks for a yMax divisible by 5", () => {
+    const ticks = getTicks(500, []);
+    expect(ticks).toEqual([100, 200, 300, 400, 500]);
+  });
+
+  it("should return ticks for a yMax divisible by 7", () => {
+    const ticks = getTicks(700, []);
+    expect(ticks).toEqual([100, 200, 300, 400, 500, 600, 700]);
+  });
+
+  it("should handle big yMax values", () => {
+    const ticks = getTicks(15000, []);
+    expect(ticks).toEqual([5000, 10000, 15000]);
+  });
+
+  it("should use fallback for non-round divisors", () => {
+    const ticks = getTicks(37, []);
+    // For yMax > 10, the fallback is 50
+    // But since 50 > 37, there's only one tick
+    expect(ticks).toEqual([]);
+  });
+
+  it("should use different fallbacks based on yMax size", () => {
+    const smallTicks = getTicks(3, []);
+    const mediumTicks = getTicks(15, []);
+    const largeTicks = getTicks(600, []);
+
+    expect(smallTicks.length).toBeGreaterThan(0);
+    expect(mediumTicks.length).toBeGreaterThan(0);
+    expect(largeTicks.length).toBeGreaterThan(0);
+  });
+
+  it("should handle decimal yMax values", () => {
+    const ticks = getTicks(2.5, []);
+    expect(ticks).toEqual([0.5, 1, 1.5, 2, 2.5]);
+  });
+
+  it("should handle zero and negative yMax", () => {
+    expect(getTicks(0, [])).toEqual([]);
+    expect(getTicks(-10, [])).toEqual([]);
+  });
+});

--- a/apps/nowcasting-app/components/helpers/chartUtils.ts
+++ b/apps/nowcasting-app/components/helpers/chartUtils.ts
@@ -62,20 +62,21 @@ export const getTicks = (yMax: number, yMax_levels: number[]) => {
   const fifth = yMax / 5;
   const seventh = yMax / 7;
   const testTicksToAdd = (fractionN: number) => {
-    if (!Number.isFinite(fractionN) || fractionN <= 0) return;
-    fractionN = Math.round(fractionN);
-    let canSplit = true;
-    let tempTicks = [];
-    for (let i = fractionN; i <= yMax; i += fractionN) {
-      if (isRoundNumber(i) || i === yMax) {
-        tempTicks.push(i);
-      } else {
-        canSplit = false;
-        break;
+    if (!Number.isFinite(fractionN)) return;
+    if (fractionN > 0) {
+      let canSplit = true;
+      let tempTicks = [];
+      for (let i = fractionN; i <= yMax; i += fractionN) {
+        if (isRoundNumber(i) || i === yMax) {
+          tempTicks.push(i);
+        } else {
+          canSplit = false;
+          break;
+        }
       }
-    }
-    if (canSplit) {
-      ticks.push(...tempTicks);
+      if (canSplit) {
+        ticks.push(...tempTicks);
+      }
     }
   };
   const isRoundNumber = (n: number) => {
@@ -109,7 +110,7 @@ export const getTicks = (yMax: number, yMax_levels: number[]) => {
     testTicksToAdd(seventh);
   }
   if (ticks.length === 0) {
-    testTicksToAdd(yMax > 500 ? 100 : 50);
+    testTicksToAdd(yMax > 500 ? 100 : yMax > 10 ? 50 : 0.5);
   }
   return ticks;
 };

--- a/apps/nowcasting-app/components/helpers/chartUtils.ts
+++ b/apps/nowcasting-app/components/helpers/chartUtils.ts
@@ -62,6 +62,8 @@ export const getTicks = (yMax: number, yMax_levels: number[]) => {
   const fifth = yMax / 5;
   const seventh = yMax / 7;
   const testTicksToAdd = (fractionN: number) => {
+    if (!Number.isFinite(fractionN) || fractionN <= 0) return;
+    fractionN = Math.round(fractionN);
     let canSplit = true;
     let tempTicks = [];
     for (let i = fractionN; i <= yMax; i += fractionN) {

--- a/apps/nowcasting-app/components/helpers/utils.test.ts
+++ b/apps/nowcasting-app/components/helpers/utils.test.ts
@@ -210,46 +210,31 @@ describe("check y-axis max value calculation", () => {
       { value1: 5000, value2: 8000 },
       { value1: 3000, value2: 7000 }
     ];
-    const result = utils.calculateChartYMax(chartData);
+    const result = utils.calculateChartYMax(chartData, 0); // the MAX_NATIONAL_GENERATION_MW is not considered for this test
     expect(result).toBe(10000); // (8000 + 1000) rounded up to nearest 2000
   });
 
   test("should ignore formattedDate fields", () => {
-    const chartData = [{ value: 6000, formattedDate: 15000 }];
-    const result = utils.calculateChartYMax(chartData);
+    const chartData = [{ value: 6000, formattedDate: "2023-10-12" }];
+    const result = utils.calculateChartYMax(chartData, 0); // the MAX_NATIONAL_GENERATION_MW is not considered for this test
     expect(result).toBe(8000); // (6000 + 1000) rounded up to nearest 2000
   });
 
-  test("should ignore fields containing TIME", () => {
-    const chartData = [{ value: 4500, TIME_VALUE: 9000 }];
-    const result = utils.calculateChartYMax(chartData);
-    expect(result).toBe(6000); // (4500 + 1000) rounded up to nearest 2000
-  });
-
   test("should handle edge case where values exactly match rounding threshold", () => {
-    const chartData = [{ value: 5000 }];
+    const chartData = [{ value: 15000 }];
     const result = utils.calculateChartYMax(chartData);
-    expect(result).toBe(8000); // (5000 + 1000) rounded up to nearest 2000
+    expect(result).toBe(18000); // (15000 + 1000) rounded up to nearest 2000
   });
 
-  test("should consider yMax if value is greater", () => {
+  test("should consider yMax if the value of yMax is greater than the Max National Generation", () => {
     const chartData = [{ value: 15000 }];
     const result = Math.max(utils.calculateChartYMax(chartData), MAX_NATIONAL_GENERATION_MW);
     expect(result).toBe(utils.calculateChartYMax(chartData));
   });
 
-  test("should consider MAX_NATIONAL_GENERATION_MW if value is less", () => {
+  test("should consider Max National Generation if the value of yMax is less than the Max National Generation", () => {
     const chartData = [{ value: 10000 }];
     const result = Math.max(utils.calculateChartYMax(chartData), MAX_NATIONAL_GENERATION_MW);
     expect(result).toBe(MAX_NATIONAL_GENERATION_MW);
-  });
-
-  test("should handle non-numeric values", () => {
-    const chartData = [
-      { value: "not-a-number", numericValue: 3000 },
-      { stringValue: "string", numericValue: 2500 }
-    ];
-    const result = utils.calculateChartYMax(chartData);
-    expect(result).toBe(6000); // (3000 + 1000) rounded up to nearest 2000
   });
 });

--- a/apps/nowcasting-app/components/helpers/utils.test.ts
+++ b/apps/nowcasting-app/components/helpers/utils.test.ts
@@ -223,7 +223,7 @@ describe("check y-axis max value calculation", () => {
   test("should handle edge case where values exactly match rounding threshold", () => {
     const chartData = [{ value: 15000 }];
     const result = utils.calculateChartYMax(chartData);
-    expect(result).toBe(18000); // (15000 + 1000) rounded up to nearest 2000
+    expect(result).toBe(17000); // (15000 + 1000) rounded up to nearest 1000
   });
 
   test("should consider yMax if the value of yMax is greater than the Max National Generation", () => {

--- a/apps/nowcasting-app/components/helpers/utils.test.ts
+++ b/apps/nowcasting-app/components/helpers/utils.test.ts
@@ -191,13 +191,13 @@ describe("check y-axis max value calculation", () => {
   });
 
   test("should round up to nearest 1000 with buffer of 1000", () => {
-    const chartData = [{ GENERATION: 12500, formattedDate: "2022-05-16T15:00" }];
+    const chartData: ChartData[] = [{ GENERATION: 12500, formattedDate: "2022-05-16T15:00" }];
     const result = utils.calculateChartYMax(chartData);
     expect(result).toBe(14000); // 12500 + 1000 = 13500 rounded to nearest 1000 is 14000
   });
 
   test("should handle multiple numeric values", () => {
-    const chartData = [
+    const chartData: ChartData[] = [
       { GENERATION: 5000, FORECAST: 8000, formattedDate: "2022-05-16T15:00" },
       { GENERATION: 3000, FORECAST: 7000, formattedDate: "2022-05-16T16:00" }
     ];
@@ -206,25 +206,25 @@ describe("check y-axis max value calculation", () => {
   });
 
   test("should ignore formattedDate fields", () => {
-    const chartData = [{ GENERATION: 15500, formattedDate: "2023-10-12" }];
+    const chartData: ChartData[] = [{ GENERATION: 15500, formattedDate: "2023-10-12" }];
     const result = utils.calculateChartYMax(chartData, 0); // the MAX_NATIONAL_GENERATION_MW is not considered for this test
     expect(result).toBe(17000); // (15500 + 1000) rounded up to nearest 1000 is 17000
   });
 
   test("should handle edge case where values exactly match rounding threshold", () => {
-    const chartData = [{ GENERATION: 15000, formattedDate: "2022-05-16T15:00" }];
+    const chartData: ChartData[] = [{ GENERATION: 15000, formattedDate: "2022-05-16T15:00" }];
     const result = utils.calculateChartYMax(chartData);
     expect(result).toBe(16000); // (15000 + 1000) rounded up to next 1000
   });
 
   test("should consider yMax if the value of yMax is greater than the Max National Generation", () => {
-    const chartData = [{ GENERATION: 15000, formattedDate: "2022-05-16T15:00" }];
+    const chartData: ChartData[] = [{ GENERATION: 15000, formattedDate: "2022-05-16T15:00" }];
     const result = Math.max(utils.calculateChartYMax(chartData), MAX_NATIONAL_GENERATION_MW);
     expect(result).toBe(utils.calculateChartYMax(chartData));
   });
 
   test("should consider Max National Generation if the value of yMax is less than the Max National Generation", () => {
-    const chartData = [{ GENERATION: 10000, formattedDate: "2022-05-16T15:00" }];
+    const chartData: ChartData[] = [{ GENERATION: 10000, formattedDate: "2022-05-16T15:00" }];
     const result = Math.max(utils.calculateChartYMax(chartData), MAX_NATIONAL_GENERATION_MW);
     expect(result).toBe(MAX_NATIONAL_GENERATION_MW);
   });

--- a/apps/nowcasting-app/components/helpers/utils.test.ts
+++ b/apps/nowcasting-app/components/helpers/utils.test.ts
@@ -6,6 +6,7 @@ import {
 } from "./utils";
 import * as utils from "./utils";
 import { MAX_NATIONAL_GENERATION_MW } from "../../constant";
+import { ChartData } from "../charts/remix-line";
 
 describe("check getOpacityValueFromPVNormalized with valid values", () => {
   test("check rounding to [0, 0.1, 0.2, 0.35, 0.5, 0.7, 1.0] and then selecting the correct opacity from [0.03, 0.2, 0.4, 0.6, 0.8, 1, 1]", () => {
@@ -184,56 +185,46 @@ describe("prettyPrintDayLabelWithDate", () => {
 });
 
 describe("check y-axis max value calculation", () => {
-  test("should return 0 when chart data is null", () => {
-    const result = utils.calculateChartYMax(null);
-    expect(result).toBe(0);
-  });
-
-  test("should return 0 when chart data is undefined", () => {
-    const result = utils.calculateChartYMax(undefined);
-    expect(result).toBe(0);
-  });
-
   test("should return 0 when chart data is empty array", () => {
     const result = utils.calculateChartYMax([]);
     expect(result).toBe(0);
   });
 
-  test("should round up to nearest 2000 with buffer of 1000", () => {
-    const chartData = [{ value: 12500 }];
+  test("should round up to nearest 1000 with buffer of 1000", () => {
+    const chartData = [{ GENERATION: 12500, formattedDate: "2022-05-16T15:00" }];
     const result = utils.calculateChartYMax(chartData);
-    expect(result).toBe(14000); // 12500 + 1000 = 13500 rounded up to nearest 2000, ie 14000
+    expect(result).toBe(14000); // 12500 + 1000 = 13500 rounded to nearest 1000 is 14000
   });
 
   test("should handle multiple numeric values", () => {
     const chartData = [
-      { value1: 5000, value2: 8000 },
-      { value1: 3000, value2: 7000 }
+      { GENERATION: 5000, FORECAST: 8000, formattedDate: "2022-05-16T15:00" },
+      { GENERATION: 3000, FORECAST: 7000, formattedDate: "2022-05-16T16:00" }
     ];
     const result = utils.calculateChartYMax(chartData, 0); // the MAX_NATIONAL_GENERATION_MW is not considered for this test
-    expect(result).toBe(10000); // (8000 + 1000) rounded up to nearest 2000
+    expect(result).toBe(9000); // (8000 + 1000) rounded up to nearest 1000 is 9000
   });
 
   test("should ignore formattedDate fields", () => {
-    const chartData = [{ value: 6000, formattedDate: "2023-10-12" }];
+    const chartData = [{ GENERATION: 15500, formattedDate: "2023-10-12" }];
     const result = utils.calculateChartYMax(chartData, 0); // the MAX_NATIONAL_GENERATION_MW is not considered for this test
-    expect(result).toBe(8000); // (6000 + 1000) rounded up to nearest 2000
+    expect(result).toBe(17000); // (15500 + 1000) rounded up to nearest 1000 is 17000
   });
 
   test("should handle edge case where values exactly match rounding threshold", () => {
-    const chartData = [{ value: 15000 }];
+    const chartData = [{ GENERATION: 15000, formattedDate: "2022-05-16T15:00" }];
     const result = utils.calculateChartYMax(chartData);
-    expect(result).toBe(17000); // (15000 + 1000) rounded up to nearest 1000
+    expect(result).toBe(16000); // (15000 + 1000) rounded up to next 1000
   });
 
   test("should consider yMax if the value of yMax is greater than the Max National Generation", () => {
-    const chartData = [{ value: 15000 }];
+    const chartData = [{ GENERATION: 15000, formattedDate: "2022-05-16T15:00" }];
     const result = Math.max(utils.calculateChartYMax(chartData), MAX_NATIONAL_GENERATION_MW);
     expect(result).toBe(utils.calculateChartYMax(chartData));
   });
 
   test("should consider Max National Generation if the value of yMax is less than the Max National Generation", () => {
-    const chartData = [{ value: 10000 }];
+    const chartData = [{ GENERATION: 10000, formattedDate: "2022-05-16T15:00" }];
     const result = Math.max(utils.calculateChartYMax(chartData), MAX_NATIONAL_GENERATION_MW);
     expect(result).toBe(MAX_NATIONAL_GENERATION_MW);
   });

--- a/apps/nowcasting-app/components/helpers/utils.ts
+++ b/apps/nowcasting-app/components/helpers/utils.ts
@@ -21,6 +21,7 @@ import * as Sentry from "@sentry/nextjs";
 import createClient from "openapi-fetch";
 import { paths } from "../../types/quartz-api";
 import { PathsWithMethod } from "openapi-typescript-helpers";
+import { ChartData } from "../charts/remix-line";
 
 export const isProduction = process.env.NEXT_PUBLIC_IS_PRODUCTION === "true";
 
@@ -574,7 +575,7 @@ export const createBucketObject: (
   };
 };
 export function calculateChartYMax(
-  chartData: Array<{ [key: string]: number | string | number[] }> | null | undefined,
+  chartData: ChartData[],
   maxY: number = MAX_NATIONAL_GENERATION_MW
 ): number {
   if (!chartData || chartData.length === 0) {
@@ -586,10 +587,7 @@ export function calculateChartYMax(
     0,
     ...chartData.flatMap((dataPoint) =>
       Object.entries(dataPoint)
-        .filter(
-          ([key, value]) =>
-            typeof value === "number" && key !== "formattedDate" && !key.includes("GENERATION")
-        )
+        .filter(([key, value]) => typeof value === "number" && key !== "formattedDate")
         .map(([_, value]) => value as number)
     )
   );
@@ -597,6 +595,5 @@ export function calculateChartYMax(
   const valueWithBuffer = maxDataValue + 1000;
   const roundingFactor = 1000;
 
-  // below the 0.01 is the epsilon value to handle the edge case where the value is exactly on the rounding factor
-  return Math.max(Math.ceil((valueWithBuffer + 0.01) / roundingFactor) * roundingFactor, maxY);
+  return Math.max(Math.ceil(valueWithBuffer / roundingFactor) * roundingFactor, maxY);
 }

--- a/apps/nowcasting-app/components/helpers/utils.ts
+++ b/apps/nowcasting-app/components/helpers/utils.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { DELTA_BUCKET, getDeltaBucketKeys } from "../../constant";
+import { DELTA_BUCKET, getDeltaBucketKeys, MAX_NATIONAL_GENERATION_MW } from "../../constant";
 import {
   Bucket,
   CombinedData,
@@ -573,9 +573,9 @@ export const createBucketObject: (
     increment
   };
 };
-
-export function calculateChartYMax<T extends Record<string, any>>(
-  chartData: T[] | null | undefined
+export function calculateChartYMax(
+  chartData: Array<{ [key: string]: number | string | number[] }> | null | undefined,
+  maxY: number = MAX_NATIONAL_GENERATION_MW
 ): number {
   if (!chartData || chartData.length === 0) {
     // If there is no data, return 0
@@ -588,7 +588,7 @@ export function calculateChartYMax<T extends Record<string, any>>(
       Object.entries(dataPoint)
         .filter(
           ([key, value]) =>
-            typeof value === "number" && key !== "formattedDate" && !key.includes("TIME")
+            typeof value === "number" && key !== "formattedDate" && !key.includes("GENERATION")
         )
         .map(([_, value]) => value as number)
     )
@@ -598,5 +598,5 @@ export function calculateChartYMax<T extends Record<string, any>>(
   const roundingFactor = 2000;
 
   // below the 0.01 is the epsilon value to handle the edge case where the value is exactly on the rounding factor
-  return Math.ceil((valueWithBuffer + 0.01) / roundingFactor) * roundingFactor;
+  return Math.max(Math.ceil((valueWithBuffer + 0.01) / roundingFactor) * roundingFactor, maxY);
 }

--- a/apps/nowcasting-app/components/helpers/utils.ts
+++ b/apps/nowcasting-app/components/helpers/utils.ts
@@ -573,3 +573,30 @@ export const createBucketObject: (
     increment
   };
 };
+
+export function calculateChartYMax<T extends Record<string, any>>(
+  chartData: T[] | null | undefined
+): number {
+  if (!chartData || chartData.length === 0) {
+    // If there is no data, return 0
+    return 0;
+  }
+
+  const maxDataValue = Math.max(
+    0,
+    ...chartData.flatMap((dataPoint) =>
+      Object.entries(dataPoint)
+        .filter(
+          ([key, value]) =>
+            typeof value === "number" && key !== "formattedDate" && !key.includes("TIME")
+        )
+        .map(([_, value]) => value as number)
+    )
+  );
+
+  const valueWithBuffer = maxDataValue + 1000;
+  const roundingFactor = 2000;
+
+  // below the 0.01 is the epsilon value to handle the edge case where the value is exactly on the rounding factor
+  return Math.ceil((valueWithBuffer + 0.01) / roundingFactor) * roundingFactor;
+}

--- a/apps/nowcasting-app/components/helpers/utils.ts
+++ b/apps/nowcasting-app/components/helpers/utils.ts
@@ -595,7 +595,7 @@ export function calculateChartYMax(
   );
 
   const valueWithBuffer = maxDataValue + 1000;
-  const roundingFactor = 2000;
+  const roundingFactor = 1000;
 
   // below the 0.01 is the epsilon value to handle the edge case where the value is exactly on the rounding factor
   return Math.max(Math.ceil((valueWithBuffer + 0.01) / roundingFactor) * roundingFactor, maxY);

--- a/apps/nowcasting-app/constant.ts
+++ b/apps/nowcasting-app/constant.ts
@@ -3,7 +3,7 @@ export const API_PREFIX = process.env.NEXT_PUBLIC_API_PREFIX || "https://api-dev
 export const SITES_API_PREFIX =
   process.env.NEXT_PUBLIC_SITES_API_PREFIX || "https://api-site-dev.quartz.solar";
 export const MAX_POWER_GENERATED = 500;
-export const MAX_NATIONAL_GENERATION_MW = 12000;
+export const MAX_NATIONAL_GENERATION_MW = 18000;
 
 export const getAllForecastUrl = (isNormalized: boolean, isHistoric: boolean) =>
   `${API_PREFIX}/solar/GB/gsp/forecast/all/?UI&${isHistoric ? "historic=true" : ""}${

--- a/apps/nowcasting-app/constant.ts
+++ b/apps/nowcasting-app/constant.ts
@@ -3,7 +3,7 @@ export const API_PREFIX = process.env.NEXT_PUBLIC_API_PREFIX || "https://api-dev
 export const SITES_API_PREFIX =
   process.env.NEXT_PUBLIC_SITES_API_PREFIX || "https://api-site-dev.quartz.solar";
 export const MAX_POWER_GENERATED = 500;
-export const MAX_NATIONAL_GENERATION_MW = 18000;
+export const MAX_NATIONAL_GENERATION_MW = 12000;
 
 export const getAllForecastUrl = (isNormalized: boolean, isHistoric: boolean) =>
   `${API_PREFIX}/solar/GB/gsp/forecast/all/?UI&${isHistoric ? "historic=true" : ""}${


### PR DESCRIPTION
# Pull Request

## Description

Increased the value of MAX_NATIONAL_GENERATION_MW to 18000 (18GW) and to prevent graph from stretching when the max value is exceeded add a buffer of 1000 and round to next 1000th value and set it as yMax  

Fixes #559

## How Has This Been Tested?

Added jest Test cases to new util function
![image](https://github.com/user-attachments/assets/36ff2535-5446-483e-82c8-0a18f14a0a00)

When yMax is 18000 
![image](https://github.com/user-attachments/assets/ca3db469-e13c-4179-846e-de1e9e7a1d69)

when yMax is 1000 to indicate data overflow.
![image](https://github.com/user-attachments/assets/820114d0-ccd2-4723-9a31-bf8eff1fb70d)


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
