### PR TITLE
Update UK National capacity chart max constant to 13.5GW

### DIFF
--- a/apps/nowcasting-app/components/charts/delta-view/delta-view-chart.tsx
+++ b/apps/nowcasting-app/components/charts/delta-view/delta-view-chart.tsx
@@ -1,10 +1,14 @@
 import { Dispatch, FC, SetStateAction, useEffect, useMemo } from "react";
 import RemixLine from "../remix-line";
-import { DELTA_BUCKET, MAX_NATIONAL_GENERATION_MW } from "../../../constant";
+import { DELTA_BUCKET, MAX_NATIONAL_GENERATION_MW, Y_MAX_TICKS } from "../../../constant";
 import ForecastHeader from "../forecast-header";
 import useGlobalState, { get30MinSlot } from "../../helpers/globalState";
 import useFormatChartData from "../use-format-chart-data";
-import { convertToLocaleDateString, formatISODateString } from "../../helpers/utils";
+import {
+  calculateChartYMax,
+  convertToLocaleDateString,
+  formatISODateString
+} from "../../helpers/utils";
 import GspPvRemixChart from "../gsp-pv-remix-chart";
 import { useStopAndResetTime } from "../../hooks/use-and-update-selected-time";
 import Spinner from "../../icons/spinner";
@@ -17,6 +21,7 @@ import DeltaBuckets from "./delta-buckets-ui";
 import useTimeNow from "../../hooks/use-time-now";
 import { ChartLegend } from "../ChartLegend";
 import DataLoadingChartStatus from "../DataLoadingChartStatus";
+import { getTicks } from "../../helpers/chartUtils";
 
 const GspDeltaColumn: FC<{
   gspDeltas: Map<string, GspDeltaValue> | undefined;
@@ -306,6 +311,10 @@ const DeltaChart: FC<DeltaChartProps> = ({ className, combinedData, combinedErro
     delta: true
   });
 
+  const yMax = useMemo(() => {
+    return calculateChartYMax(chartData, MAX_NATIONAL_GENERATION_MW);
+  }, [chartData]);
+
   // While N-hour is not available, we default to the latest interval with an Initial Estimate
   // useEffect(() => {
   //   if (selectedISOTime === get30MinNow() && view === VIEWS.DELTA) {
@@ -351,7 +360,8 @@ const DeltaChart: FC<DeltaChartProps> = ({ className, combinedData, combinedErro
               timeOfInterest={selectedTime}
               setTimeOfInterest={setSelectedTime}
               data={chartData}
-              yMax={MAX_NATIONAL_GENERATION_MW}
+              yMax={yMax}
+              yTicks={getTicks(yMax, Y_MAX_TICKS)}
               visibleLines={visibleLines}
               deltaView={true}
             />

--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
@@ -14,20 +14,7 @@ import { ForecastValue } from "../../types";
 import React, { FC } from "react";
 import { NationalAggregation } from "../../map/types";
 import { getTicks } from "../../helpers/chartUtils";
-
-// Static constant below of this function so we don't call dynamically unnecessarily.
-// import { generateYMaxTickArray } from "../../helpers/chartUtils";
-// console.log("Y_MAX_TICKS", generateYMaxTickArray());
-//
-// We want to have the yMax of the graph to be related to the capacity of the GspPvRemixChart.
-// If we use the raw values, the graph looks funny, i.e y major ticks are 0 100 232
-// So, we round these up to the following numbers, which hopefully split nicely into the y-axis.
-// Uncomment the above function to get updated values should we need to change these
-const Y_MAX_TICKS = [
-  1, 2, 3, 4, 5, 6, 9, 10, 12, 15, 18, 20, 25, 30, 40, 45, 50, 60, 75, 80, 90, 100, 150, 200, 250,
-  300, 350, 400, 450, 500, 600, 700, 800, 900, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000,
-  6000, 7000, 8000, 9000, 10000, 12000, 14000, 15000, 16000, 18000, 20000
-];
+import { Y_MAX_TICKS } from "../../../constant";
 
 const GspPvRemixChart: FC<{
   gspId: number | string;

--- a/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
+++ b/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
@@ -7,7 +7,7 @@ import { formatISODateString } from "../helpers/utils";
 import GspPvRemixChart from "./gsp-pv-remix-chart";
 import { useStopAndResetTime } from "../hooks/use-and-update-selected-time";
 import Spinner from "../icons/spinner";
-import { MAX_NATIONAL_GENERATION_MW } from "../../constant";
+import { MAX_NATIONAL_GENERATION_MW, Y_MAX_TICKS } from "../../constant";
 import useHotKeyControlChart from "../hooks/use-hot-key-control-chart";
 import { CombinedData, CombinedErrors } from "../types";
 import { ChartLegend } from "./ChartLegend";
@@ -113,7 +113,7 @@ const PvRemixChart: FC<{
               data={chartData}
               yMax={yMax}
               visibleLines={visibleLines}
-              yTicks={getTicks(yMax, [])}
+              yTicks={getTicks(yMax, Y_MAX_TICKS)}
             />
           </div>
         </div>

--- a/apps/nowcasting-app/components/helpers/chartUtils.test.ts
+++ b/apps/nowcasting-app/components/helpers/chartUtils.test.ts
@@ -34,7 +34,7 @@ describe("getTicks", () => {
 
   it("should return the correct ticks for a yMax of 14000", () => {
     const ticks = getTicks(14000, []);
-    expect(ticks).toEqual([2000, 4000, 6000, 8000, 10000, 12000, 14000]);
+    expect(ticks).toEqual([3000, 6000, 9000, 12000]);
   });
 
   it("should return the correct ticks for a yMax of 15000", () => {

--- a/apps/nowcasting-app/components/helpers/chartUtils.test.ts
+++ b/apps/nowcasting-app/components/helpers/chartUtils.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from "@jest/globals";
 
 describe("getTicks", () => {
   it("should return ticks for a yMax divisible by 3", () => {
-    const ticks = getTicks(300, []);
-    expect(ticks).toEqual([100, 200, 300]);
+    const ticks = getTicks(270, []);
+    expect(ticks).toEqual([90, 180, 270]);
   });
 
   it("should return ticks for a yMax divisible by 4", () => {
@@ -17,14 +17,89 @@ describe("getTicks", () => {
     expect(ticks).toEqual([100, 200, 300, 400, 500]);
   });
 
+  it("should return ticks for a yMax divisible by 6", () => {
+    const ticks = getTicks(600, []);
+    expect(ticks).toEqual([100, 200, 300, 400, 500, 600]);
+  });
+
   it("should return ticks for a yMax divisible by 7", () => {
     const ticks = getTicks(700, []);
     expect(ticks).toEqual([100, 200, 300, 400, 500, 600, 700]);
   });
 
-  it("should handle big yMax values", () => {
+  it("should return the correct ticks for a yMax of 13000", () => {
+    const ticks = getTicks(13000, []);
+    expect(ticks).toEqual([3000, 6000, 9000, 12000]);
+  });
+
+  it("should return the correct ticks for a yMax of 14000", () => {
+    const ticks = getTicks(14000, []);
+    expect(ticks).toEqual([2000, 4000, 6000, 8000, 10000, 12000, 14000]);
+  });
+
+  it("should return the correct ticks for a yMax of 15000", () => {
     const ticks = getTicks(15000, []);
-    expect(ticks).toEqual([5000, 10000, 15000]);
+    expect(ticks).toEqual([3000, 6000, 9000, 12000, 15000]);
+  });
+
+  it("should return the correct ticks for a yMax of 50", () => {
+    const ticks = getTicks(50, []);
+    expect(ticks).toEqual([10, 20, 30, 40, 50]);
+  });
+
+  it("should return the correct ticks for a yMax of 100", () => {
+    const ticks = getTicks(100, []);
+    expect(ticks).toEqual([20, 40, 60, 80, 100]);
+  });
+
+  it("should return the correct ticks for a yMax of 150", () => {
+    const ticks = getTicks(150, []);
+    expect(ticks).toEqual([30, 60, 90, 120, 150]);
+  });
+
+  it("should return the correct ticks for a yMax of 200", () => {
+    const ticks = getTicks(200, []);
+    expect(ticks).toEqual([40, 80, 120, 160, 200]);
+  });
+
+  it("should return the correct ticks for a yMax of 250", () => {
+    const ticks = getTicks(250, []);
+    expect(ticks).toEqual([50, 100, 150, 200, 250]);
+  });
+
+  it("should return the correct ticks for a yMax of 300", () => {
+    const ticks = getTicks(300, []);
+    expect(ticks).toEqual([50, 100, 150, 200, 250, 300]);
+  });
+
+  it("should return the correct ticks for a yMax of 350", () => {
+    const ticks = getTicks(350, []);
+    expect(ticks).toEqual([50, 100, 150, 200, 250, 300, 350]);
+  });
+
+  it("should return the correct ticks for a yMax of 400", () => {
+    const ticks = getTicks(400, []);
+    expect(ticks).toEqual([100, 200, 300, 400]);
+  });
+
+  it("should return the correct ticks for a yMax of 450", () => {
+    const ticks = getTicks(450, []);
+    expect(ticks).toEqual([150, 300, 450]);
+  });
+
+  it("should return the correct ticks for a yMax of 500", () => {
+    const ticks = getTicks(500, []);
+    expect(ticks).toEqual([100, 200, 300, 400, 500]);
+  });
+
+  it("should return the correct ticks for a yMax of 600", () => {
+    const ticks = getTicks(600, []);
+    expect(ticks).toEqual([100, 200, 300, 400, 500, 600]);
+  });
+
+  it("should return the correct ticks for a yMax of 700", () => {
+    const ticks = getTicks(700, []);
+    expect(ticks).toEqual([100, 200, 300, 400, 500, 600, 700]);
   });
 
   it("should use fallback for non-round divisors", () => {

--- a/apps/nowcasting-app/components/helpers/chartUtils.ts
+++ b/apps/nowcasting-app/components/helpers/chartUtils.ts
@@ -58,7 +58,7 @@ export const generateYMaxTickArray = () => {
 };
 
 export const getTicks = (yMax: number, yMax_levels: number[]) => {
-  if (yMax === 13000) {
+  if (yMax === 13000 || yMax === 14000) {
     return [3000, 6000, 9000, 12000];
   }
   const ticks: number[] = [];

--- a/apps/nowcasting-app/components/helpers/chartUtils.ts
+++ b/apps/nowcasting-app/components/helpers/chartUtils.ts
@@ -58,7 +58,7 @@ export const generateYMaxTickArray = () => {
 };
 
 export const getTicks = (yMax: number, yMax_levels: number[]) => {
-  if (yMax === 13000 || yMax === 14000) {
+  if (yMax >= 13000 && yMax < 15000) {
     return [3000, 6000, 9000, 12000];
   }
   const ticks: number[] = [];

--- a/apps/nowcasting-app/components/helpers/chartUtils.ts
+++ b/apps/nowcasting-app/components/helpers/chartUtils.ts
@@ -47,7 +47,9 @@ export const generateYMaxTickArray = () => {
   // Multiples of 500
   yMax_levels = [...yMax_levels, ...Array.from({ length: 10 }, (_, i) => (i + 1) * 500)];
   // Multiples of 1000
-  yMax_levels = [...yMax_levels, ...Array.from({ length: 10 }, (_, i) => (i + 1) * 1000)];
+  yMax_levels = [...yMax_levels, ...Array.from({ length: 15 }, (_, i) => (i + 1) * 1000)];
+  // Multiples of 2500
+  yMax_levels = [...yMax_levels, ...Array.from({ length: 5 }, (_, i) => (i + 1) * 2500)];
   // Remove duplicates
   yMax_levels = [...new Set(yMax_levels)];
   // Sort
@@ -56,10 +58,14 @@ export const generateYMaxTickArray = () => {
 };
 
 export const getTicks = (yMax: number, yMax_levels: number[]) => {
+  if (yMax === 13000) {
+    return [3000, 6000, 9000, 12000];
+  }
   const ticks: number[] = [];
   const third = yMax / 3;
   const quarter = yMax / 4;
   const fifth = yMax / 5;
+  const sixth = yMax / 6;
   const seventh = yMax / 7;
   const testTicksToAdd = (fractionN: number) => {
     if (!Number.isFinite(fractionN)) return;
@@ -102,14 +108,17 @@ export const getTicks = (yMax: number, yMax_levels: number[]) => {
     }
     return n % 0.5 === 0;
   };
-  if (isRoundNumber(third)) {
-    testTicksToAdd(third);
+  if (ticks.length === 0 && isRoundNumber(fifth)) {
+    testTicksToAdd(fifth);
+  }
+  if (ticks.length === 0 && isRoundNumber(sixth)) {
+    testTicksToAdd(sixth);
   }
   if (ticks.length === 0 && isRoundNumber(quarter)) {
     testTicksToAdd(quarter);
   }
-  if (ticks.length === 0 && isRoundNumber(fifth)) {
-    testTicksToAdd(fifth);
+  if (ticks.length === 0 && isRoundNumber(third)) {
+    testTicksToAdd(third);
   }
   if (ticks.length === 0 && isRoundNumber(seventh)) {
     testTicksToAdd(seventh);

--- a/apps/nowcasting-app/components/helpers/chartUtils.ts
+++ b/apps/nowcasting-app/components/helpers/chartUtils.ts
@@ -67,6 +67,11 @@ export const getTicks = (yMax: number, yMax_levels: number[]) => {
       let canSplit = true;
       let tempTicks = [];
       for (let i = fractionN; i <= yMax; i += fractionN) {
+        /*
+         TODO: this could check against the yMax_levels array / constant for strictly sticking
+         to the levels we want to show; but we need to be careful not to inhibit the default
+          behaviour of the chart library doing its job.
+        */
         if (isRoundNumber(i) || i === yMax) {
           tempTicks.push(i);
         } else {
@@ -81,7 +86,7 @@ export const getTicks = (yMax: number, yMax_levels: number[]) => {
   };
   const isRoundNumber = (n: number) => {
     if (n > 2000) {
-      return n % 500 === 0;
+      return n % 2500 === 0 || n % 1000 === 0;
     }
     if (n > 1000) {
       return n % 250 === 0 || n % 100 === 0;

--- a/apps/nowcasting-app/components/helpers/utils.test.ts
+++ b/apps/nowcasting-app/components/helpers/utils.test.ts
@@ -190,10 +190,16 @@ describe("check y-axis max value calculation", () => {
     expect(result).toBe(0);
   });
 
-  test("should round up to nearest 1000 with buffer of 1000", () => {
+  test("should round up to nearest 1000 with buffer of 1000, and return MAX_NATIONAL if lower", () => {
     const chartData: ChartData[] = [{ GENERATION: 12500, formattedDate: "2022-05-16T15:00" }];
     const result = utils.calculateChartYMax(chartData);
-    expect(result).toBe(14000); // 12500 + 1000 = 13500 rounded to nearest 1000 is 14000
+    expect(result).toBe(MAX_NATIONAL_GENERATION_MW); // 12500 + 1000 = 13500 rounded to nearest 1000 is 14000, which is less than MAX_NATIONAL_GENERATION_MW
+  });
+
+  test("should round up to nearest 1000 with buffer of 1000", () => {
+    const chartData: ChartData[] = [{ GENERATION: 14500, formattedDate: "2022-05-16T15:00" }];
+    const result = utils.calculateChartYMax(chartData);
+    expect(result).toBe(16000); // 12500 + 1000 = 13500 rounded to nearest 1000 is 14000, which is less than MAX_NATIONAL_GENERATION_MW
   });
 
   test("should handle multiple numeric values", () => {

--- a/apps/nowcasting-app/components/helpers/utils.test.ts
+++ b/apps/nowcasting-app/components/helpers/utils.test.ts
@@ -190,16 +190,22 @@ describe("check y-axis max value calculation", () => {
     expect(result).toBe(0);
   });
 
-  test("should round up to nearest 1000 with buffer of 1000, and return MAX_NATIONAL if lower", () => {
+  test("should round up to nearest 500 with buffer of 100, and return MAX_NATIONAL if lower", () => {
     const chartData: ChartData[] = [{ GENERATION: 10500, formattedDate: "2022-05-16T15:00" }];
     const result = utils.calculateChartYMax(chartData);
-    expect(result).toBe(MAX_NATIONAL_GENERATION_MW); // 10500 + 1000 = 11500 rounded to nearest 1000 is 12000, which is less than MAX_NATIONAL_GENERATION_MW
+    expect(result).toBe(MAX_NATIONAL_GENERATION_MW); // 10500 + 100 = 10600 rounded to nearest 500 is 11000, which is less than MAX_NATIONAL_GENERATION_MW
   });
 
-  test("should round up to nearest 1000 with buffer of 1000", () => {
-    const chartData: ChartData[] = [{ GENERATION: 14500, formattedDate: "2022-05-16T15:00" }];
+  test("should round up to next nearest 500 with buffer of 100", () => {
+    const chartData: ChartData[] = [{ GENERATION: 14450, formattedDate: "2022-05-16T15:00" }];
     const result = utils.calculateChartYMax(chartData);
-    expect(result).toBe(16000); // 12500 + 1000 = 13500 rounded to nearest 1000 is 14000, which is less than MAX_NATIONAL_GENERATION_MW
+    expect(result).toBe(15000); // 12500 + 1000 = 13500 rounded to nearest 1000 is 14000, which is more than MAX_NATIONAL_GENERATION_MW
+  });
+
+  test("should round up to nearest 500 with buffer of 100", () => {
+    const chartData: ChartData[] = [{ GENERATION: 14350, formattedDate: "2022-05-16T15:00" }];
+    const result = utils.calculateChartYMax(chartData);
+    expect(result).toBe(14500); // 14350 + 100 = 14450 rounded to nearest 500 is 14500, which is more than MAX_NATIONAL_GENERATION_MW
   });
 
   test("should handle multiple numeric values", () => {
@@ -208,19 +214,25 @@ describe("check y-axis max value calculation", () => {
       { GENERATION: 3000, FORECAST: 7000, formattedDate: "2022-05-16T16:00" }
     ];
     const result = utils.calculateChartYMax(chartData, 0); // the MAX_NATIONAL_GENERATION_MW is not considered for this test
-    expect(result).toBe(9000); // (8000 + 1000) rounded up to nearest 1000 is 9000
+    expect(result).toBe(8500); // (8000 + 100) rounded up to nearest 500 is 8500
   });
 
   test("should ignore formattedDate fields", () => {
     const chartData: ChartData[] = [{ GENERATION: 15500, formattedDate: "2023-10-12" }];
     const result = utils.calculateChartYMax(chartData, 0); // the MAX_NATIONAL_GENERATION_MW is not considered for this test
-    expect(result).toBe(17000); // (15500 + 1000) rounded up to nearest 1000 is 17000
+    expect(result).toBe(16000); // (15500 + 100) rounded up to nearest 500 is 16000
+  });
+
+  test("should handle edge case where value is just under rounding threshold", () => {
+    const chartData: ChartData[] = [{ GENERATION: 14990, formattedDate: "2022-05-16T15:00" }];
+    const result = utils.calculateChartYMax(chartData);
+    expect(result).toBe(15500); // (14990 + 100) rounded up to next 500
   });
 
   test("should handle edge case where values exactly match rounding threshold", () => {
     const chartData: ChartData[] = [{ GENERATION: 15000, formattedDate: "2022-05-16T15:00" }];
     const result = utils.calculateChartYMax(chartData);
-    expect(result).toBe(16000); // (15000 + 1000) rounded up to next 1000
+    expect(result).toBe(15500); // (15000 + 100) rounded up to next 500
   });
 
   test("should consider yMax if the value of yMax is greater than the Max National Generation", () => {

--- a/apps/nowcasting-app/components/helpers/utils.test.ts
+++ b/apps/nowcasting-app/components/helpers/utils.test.ts
@@ -191,9 +191,9 @@ describe("check y-axis max value calculation", () => {
   });
 
   test("should round up to nearest 1000 with buffer of 1000, and return MAX_NATIONAL if lower", () => {
-    const chartData: ChartData[] = [{ GENERATION: 12500, formattedDate: "2022-05-16T15:00" }];
+    const chartData: ChartData[] = [{ GENERATION: 10500, formattedDate: "2022-05-16T15:00" }];
     const result = utils.calculateChartYMax(chartData);
-    expect(result).toBe(MAX_NATIONAL_GENERATION_MW); // 12500 + 1000 = 13500 rounded to nearest 1000 is 14000, which is less than MAX_NATIONAL_GENERATION_MW
+    expect(result).toBe(MAX_NATIONAL_GENERATION_MW); // 10500 + 1000 = 11500 rounded to nearest 1000 is 12000, which is less than MAX_NATIONAL_GENERATION_MW
   });
 
   test("should round up to nearest 1000 with buffer of 1000", () => {

--- a/apps/nowcasting-app/components/helpers/utils.ts
+++ b/apps/nowcasting-app/components/helpers/utils.ts
@@ -592,8 +592,8 @@ export function calculateChartYMax(
     )
   );
 
-  const valueWithBuffer = maxDataValue + 1000;
-  const roundingFactor = 1000;
+  const valueWithBuffer = maxDataValue + 100;
+  const roundingFactor = 500;
 
   return Math.max(Math.ceil(valueWithBuffer / roundingFactor) * roundingFactor, maxY);
 }

--- a/apps/nowcasting-app/constant.ts
+++ b/apps/nowcasting-app/constant.ts
@@ -3,10 +3,10 @@ export const API_PREFIX = process.env.NEXT_PUBLIC_API_PREFIX || "https://api-dev
 export const SITES_API_PREFIX =
   process.env.NEXT_PUBLIC_SITES_API_PREFIX || "https://api-site-dev.quartz.solar";
 export const MAX_POWER_GENERATED = 500;
-export const MAX_NATIONAL_GENERATION_MW = 14000;
+export const MAX_NATIONAL_GENERATION_MW = 15000;
 
 // Static constant below of this function so we don't call dynamically unnecessarily.
-// import { generateYMaxTickArray } from "../../helpers/chartUtils";
+// import { generateYMaxTickArray } from "./components/helpers/chartUtils";
 // console.log("Y_MAX_TICKS", generateYMaxTickArray());
 //
 // We want to have the yMax of the graph to be related to the capacity of the GspPvRemixChart.
@@ -16,7 +16,7 @@ export const MAX_NATIONAL_GENERATION_MW = 14000;
 export const Y_MAX_TICKS = [
   1, 2, 3, 4, 5, 6, 9, 10, 12, 15, 18, 20, 25, 30, 40, 45, 50, 60, 75, 80, 90, 100, 150, 200, 250,
   300, 350, 400, 450, 500, 600, 700, 800, 900, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000,
-  6000, 7000, 8000, 9000, 10000, 12000, 14000, 15000, 16000, 18000, 20000
+  6000, 7000, 7500, 8000, 9000, 10000, 11000, 12000, 12500, 13000, 14000, 15000
 ];
 
 export const getAllForecastUrl = (isNormalized: boolean, isHistoric: boolean) =>

--- a/apps/nowcasting-app/constant.ts
+++ b/apps/nowcasting-app/constant.ts
@@ -3,7 +3,7 @@ export const API_PREFIX = process.env.NEXT_PUBLIC_API_PREFIX || "https://api-dev
 export const SITES_API_PREFIX =
   process.env.NEXT_PUBLIC_SITES_API_PREFIX || "https://api-site-dev.quartz.solar";
 export const MAX_POWER_GENERATED = 500;
-export const MAX_NATIONAL_GENERATION_MW = 15000;
+export const MAX_NATIONAL_GENERATION_MW = 13000;
 
 // Static constant below of this function so we don't call dynamically unnecessarily.
 // import { generateYMaxTickArray } from "./components/helpers/chartUtils";

--- a/apps/nowcasting-app/constant.ts
+++ b/apps/nowcasting-app/constant.ts
@@ -3,7 +3,7 @@ export const API_PREFIX = process.env.NEXT_PUBLIC_API_PREFIX || "https://api-dev
 export const SITES_API_PREFIX =
   process.env.NEXT_PUBLIC_SITES_API_PREFIX || "https://api-site-dev.quartz.solar";
 export const MAX_POWER_GENERATED = 500;
-export const MAX_NATIONAL_GENERATION_MW = 13000;
+export const MAX_NATIONAL_GENERATION_MW = 14000;
 
 // Static constant below of this function so we don't call dynamically unnecessarily.
 // import { generateYMaxTickArray } from "./components/helpers/chartUtils";

--- a/apps/nowcasting-app/constant.ts
+++ b/apps/nowcasting-app/constant.ts
@@ -3,7 +3,21 @@ export const API_PREFIX = process.env.NEXT_PUBLIC_API_PREFIX || "https://api-dev
 export const SITES_API_PREFIX =
   process.env.NEXT_PUBLIC_SITES_API_PREFIX || "https://api-site-dev.quartz.solar";
 export const MAX_POWER_GENERATED = 500;
-export const MAX_NATIONAL_GENERATION_MW = 12000;
+export const MAX_NATIONAL_GENERATION_MW = 14000;
+
+// Static constant below of this function so we don't call dynamically unnecessarily.
+// import { generateYMaxTickArray } from "../../helpers/chartUtils";
+// console.log("Y_MAX_TICKS", generateYMaxTickArray());
+//
+// We want to have the yMax of the graph to be related to the capacity of the GspPvRemixChart.
+// If we use the raw values, the graph looks funny, i.e y major ticks are 0 100 232
+// So, we round these up to the following numbers, which hopefully split nicely into the y-axis.
+// Uncomment the above function to get updated values should we need to change these
+export const Y_MAX_TICKS = [
+  1, 2, 3, 4, 5, 6, 9, 10, 12, 15, 18, 20, 25, 30, 40, 45, 50, 60, 75, 80, 90, 100, 150, 200, 250,
+  300, 350, 400, 450, 500, 600, 700, 800, 900, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000,
+  6000, 7000, 8000, 9000, 10000, 12000, 14000, 15000, 16000, 18000, 20000
+];
 
 export const getAllForecastUrl = (isNormalized: boolean, isHistoric: boolean) =>
   `${API_PREFIX}/solar/GB/gsp/forecast/all/?UI&${isHistoric ? "historic=true" : ""}${

--- a/apps/nowcasting-app/constant.ts
+++ b/apps/nowcasting-app/constant.ts
@@ -3,7 +3,7 @@ export const API_PREFIX = process.env.NEXT_PUBLIC_API_PREFIX || "https://api-dev
 export const SITES_API_PREFIX =
   process.env.NEXT_PUBLIC_SITES_API_PREFIX || "https://api-site-dev.quartz.solar";
 export const MAX_POWER_GENERATED = 500;
-export const MAX_NATIONAL_GENERATION_MW = 14000;
+export const MAX_NATIONAL_GENERATION_MW = 13500;
 
 // Static constant below of this function so we don't call dynamically unnecessarily.
 // import { generateYMaxTickArray } from "./components/helpers/chartUtils";


### PR DESCRIPTION
## Description

After discussion with the team, opting to up the National limit to maintain balance between consistency (user being accustomed to a certain scale when glancing at the National chart) and the changeable nature of our forecast daily peaks, probabilistic upper bound, etc.

Also:
- applies the new Y max logic to Delta view (missed by myself when reviewing the recent PR);
- improves the rounding for larger Y max values in the >2000MW range, keeping to 1,000 or 2,500 increments;
- amended the getTicks logic for divisions, in preference order: fifths, sixths, quarters, thirds, sevenths.

Fixes #103 (again)

## How Has This Been Tested?

- [x] Vercel branch

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
