### PR TITLE
Fix DNO chart not loading data successfully

### DIFF
--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/use-get-gsp-data.ts
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/use-get-gsp-data.ts
@@ -7,6 +7,7 @@ import useGlobalState from "../../helpers/globalState";
 import { useLoadDataFromApi } from "../../hooks/useLoadDataFromApi";
 import { NationalAggregation } from "../../map/types";
 import { components } from "../../../types/quartz-api";
+import { getEarliestForecastTimestamp } from "../../helpers/data";
 
 const aggregateTruthData = (
   pvDataRaw: components["schemas"]["GSPYieldGroupByDatetime"][] | undefined,
@@ -70,7 +71,7 @@ const useGetGspData = (gspId: number | string) => {
   if (nationalAggregationLevel === NationalAggregation.national) {
     gspIds = nationalGspZone[gspId as keyof typeof nationalGspZone] || [];
   }
-  if (Number(gspId) !== 0) {
+  if (nationalAggregationLevel === NationalAggregation.GSP && Number(gspId) !== 0) {
     gspIds = [Number(gspId)];
   }
 
@@ -96,6 +97,7 @@ const useGetGspData = (gspId: number | string) => {
   );
   const pvRealDataAfter = aggregateTruthData(pvRealDataAfterRaw, gspIds, "solarGenerationKw");
 
+  const startDatetime = getEarliestForecastTimestamp();
   const {
     data: gspForecastDataOneGSPRaw,
     isLoading: gspForecastSelectedGSPsLoading,
@@ -103,7 +105,7 @@ const useGetGspData = (gspId: number | string) => {
   } = useLoadDataFromApi<components["schemas"]["OneDatetimeManyForecastValues"][]>(
     `${API_PREFIX}/solar/GB/gsp/forecast/all/?gsp_ids=${encodeURIComponent(
       gspIds.join(",")
-    )}&compact=true&historic=true`,
+    )}&compact=true&historic=true&start_datetime_utc=${encodeURIComponent(startDatetime)}`,
     {
       dedupingInterval: 1000 * 30
     }


### PR DESCRIPTION
# Pull Request

## Description

Two small things but related:
- bug: introduced in the latest release, where the DNO's gsp_ids array is incorrectly cast as a [Number], leading to a NaN in the API call
- bug: existing since API update in May, requiring the DNO to explicitly provide a start_datetime for the /gsp/forecast/all call to give history

Fixes #604 

## How Has This Been Tested?

- [x] Local
- [x] Vercel Preview: https://nowcasting-app-git-fix-dno-forecast-nan-bug-openclimatefix.vercel.app/

![image](https://github.com/user-attachments/assets/48d085f8-9a76-4e90-b7a8-70c6df5ce266)


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
