### PR TITLE
✨ Quartz Solar v0.5.7 → Staging

### DIFF
--- a/apps/nowcasting-app/package.json
+++ b/apps/nowcasting-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclimatefix/nowcasting-app",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",


### PR DESCRIPTION

# Pull Request

## Description

Two small things but related:
- bug: introduced in the latest release, where the DNO's gsp_ids array is incorrectly cast as a [Number], leading to a NaN in the API call
- bug: existing since API update in May, requiring the DNO to explicitly provide a start_datetime for the /gsp/forecast/all call to give history

Fixes #604 

## How Has This Been Tested?

- [x] Local
- [x] Vercel Preview: https://nowcasting-app-git-fix-dno-forecast-nan-bug-openclimatefix.vercel.app/
- [ ] Development: https://dev.quartz.solar/

![image](https://github.com/user-attachments/assets/48d085f8-9a76-4e90-b7a8-70c6df5ce266)


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
