### PR TITLE
add check for pvlive sort order & reverse if needed

### DIFF
--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
@@ -80,10 +80,12 @@ const GspPvRemixChart: FC<{
   //
 
   // get the latest Actual pv value in GW
-  const latestPvActualInMW = KWtoMW(pvRealDataIn?.[0]?.solarGenerationKw || 0);
+  const latestPvActualInMW = KWtoMW(
+    pvRealDataIn?.[pvRealDataIn.length - 1]?.solarGenerationKw || 0
+  );
 
   // get pv time
-  const latestPvActualDatetime = pvRealDataIn?.[0]?.datetimeUtc || timeNow;
+  const latestPvActualDatetime = pvRealDataIn?.[pvRealDataIn.length - 1]?.datetimeUtc || timeNow;
 
   // Use the same time for the Forecast historic
   const pvForecastDatetime = formatISODateString(latestPvActualDatetime);

--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/use-get-gsp-data.ts
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/use-get-gsp-data.ts
@@ -8,6 +8,7 @@ import { useLoadDataFromApi } from "../../hooks/useLoadDataFromApi";
 import { NationalAggregation } from "../../map/types";
 import { components } from "../../../types/quartz-api";
 import { getEarliestForecastTimestamp } from "../../helpers/data";
+import * as Sentry from "@sentry/react";
 
 const aggregateTruthData = (
   pvDataRaw: components["schemas"]["GSPYieldGroupByDatetime"][] | undefined,
@@ -15,6 +16,12 @@ const aggregateTruthData = (
   key: string
 ) => {
   if (!pvDataRaw?.length) return [];
+
+  if (pvDataRaw[0].datetimeUtc > pvDataRaw[pvDataRaw.length - 1].datetimeUtc) {
+    // If the data is not in chronological order, i.e. oldest first, reverse it
+    Sentry.captureMessage("Reversing pvDataRaw order in aggregateTruthData", "info");
+    pvDataRaw = pvDataRaw.reverse();
+  }
   return pvDataRaw?.map((d) => {
     return {
       datetimeUtc: d.datetimeUtc,


### PR DESCRIPTION
# Pull Request

## Description

Add check for pvlive sort order during PVLive data aggregation
if not new order, reverse the array

Fixes #613

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [x] Locally
- [x] Vercel preview

- [x] _If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
