### PR TITLE
Reset aggregation to GSP when switching to Delta view

### DIFF
--- a/apps/nowcasting-app/pages/index.tsx
+++ b/apps/nowcasting-app/pages/index.tsx
@@ -75,7 +75,9 @@ export default function Home({ dashboardModeServer }: { dashboardModeServer: str
   const [, setSitesLoadingState] = useGlobalState("sitesLoadingState");
   const [, setLoadingState] = useGlobalState("loadingState");
   const [nHourForecast] = useGlobalState("nHourForecast");
-  const [nationalAggregationLevel] = useGlobalState("nationalAggregationLevel");
+  const [nationalAggregationLevel, setNationalAggregationLevel] = useGlobalState(
+    "nationalAggregationLevel"
+  );
   const [, setClickedGspId] = useGlobalState("clickedGspId");
 
   const [forecastLastFetch30MinISO, setForecastLastFetch30MinISO] = useState(get30MinNow(-30));
@@ -112,10 +114,14 @@ export default function Home({ dashboardModeServer }: { dashboardModeServer: str
     setArraySettingInCookieStorage(CookieStorageKeys.VISIBLE_LINES, visibleLines);
   }, [visibleLines]);
 
-  // On view change, unset the clicked "GSP" if the aggregation is not GSP
+  // On view change, unset the clicked GSP if the aggregation is not GSP,
+  // and set the national aggregation level to GSP if we're now on Delta view
   useEffect(() => {
     if (nationalAggregationLevel !== NationalAggregation.GSP) {
       setClickedGspId(undefined);
+    }
+    if (view === VIEWS.DELTA) {
+      setNationalAggregationLevel(NationalAggregation.GSP);
     }
   }, [view]);
 

--- a/apps/nowcasting-app/pages/index.tsx
+++ b/apps/nowcasting-app/pages/index.tsx
@@ -114,7 +114,7 @@ export default function Home({ dashboardModeServer }: { dashboardModeServer: str
     setArraySettingInCookieStorage(CookieStorageKeys.VISIBLE_LINES, visibleLines);
   }, [visibleLines]);
 
-  // On view change, unset the clicked GSP if the aggregation is not GSP,
+  // On view change, unset the clicked region if the aggregation is not GSP,
   // and set the national aggregation level to GSP if we're now on Delta view
   useEffect(() => {
     if (nationalAggregationLevel !== NationalAggregation.GSP) {


### PR DESCRIPTION
# Pull Request

## Description

Reset aggregation to GSP when switching to Delta view.

Fixes #622 

## How Has This Been Tested?

- [x] Locally
- [x] Vercel Preview branch: https://nowcasting-app-git-hotfix-dno-delta-select-bug-openclimatefix.vercel.app/

Current dev:
<img width="1753" height="1122" alt="Google Chrome 2025-07-15 10 48 53" src="https://github.com/user-attachments/assets/015878e2-28d1-47b1-a82a-c02b337ce71d" />

Preview:
<img width="1753" height="1122" alt="image" src="https://github.com/user-attachments/assets/0c565c52-0988-43a0-a902-cecb5fb05291" />



## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
