### PR TITLE
Fix broken Wired article link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Head to [quartz.solar](https://quartz.solar) to find out more or to get in touch
 
 ## Solar Electricity Nowcasting UI
 
-The `nowcasting-app` is the repository for [Open Climate Fix](https://openclimatefix.org/)'s solar electricity nowcasting project. See [this great Wired article about OCF's solar electricity forecasting work](https://www.wired.co.uk/article/solar-weather-forecasting) for a good intro to solar electricity nowcasting.
+The `nowcasting-app` is the repository for [Open Climate Fix](https://openclimatefix.org/)'s solar electricity nowcasting project. See [Open Climate Fix’s blog post on starting solar electricity nowcasting](https://web.archive.org/web/20210322094406/https://openclimatefix.org/blog/2019-07-01-starting-solar-electricity-nowcasting/) for a good intro to solar electricity nowcasting.
+
 
 The plan is to enable the community to build the world's best near-term forecasting system for solar electricity generation, and then let anyone use it! :) We'll do this by using state-of-the-art machine learning and 5-minutely satellite imagery to predict the movement of clouds over the next few hours, and then use this to predict solar electricity generation.
 


### PR DESCRIPTION
The README referenced a Wired article about Open Climate Fix’s solar electricity forecasting work, but the link no longer resolves.

This PR replaces the broken Wired URL with a verified Wayback Machine snapshot of the official Open Climate Fix blog post that provides the same introductory context on solar electricity nowcasting.

Pull Request
Description

Fixes #665.

This change updates the README to replace a broken Wired article link about Open Climate Fix’s solar electricity forecasting work. The original Wired URL no longer resolves.

The link has been replaced with a verified Wayback Machine snapshot of the official Open Climate Fix blog post, which provides the same introductory context on solar electricity nowcasting.

How Has This Been Tested?

The updated README link was manually tested by opening it in a web browser and confirming that the page loads successfully.
