### PR TITLE
Fix sidebar text overflow when content wraps

### DIFF
--- a/apps/quartz-app/src/components/Sidebar.tsx
+++ b/apps/quartz-app/src/components/Sidebar.tsx
@@ -269,7 +269,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             </div>
             <hr className="border-white/50 my-3 mb-5" />
 
-            <div className="flex-1 self-stretch h-[39px] justify-between mb-6 items-start gap-16 flex">
+            <div className="flex-1 self-stretch min-h-[39px] justify-between mb-6 items-start gap-16 flex">
               <ForecastTimeDisplay
                 time={prettyPrintNowTime()}
                 icon={<ClockIcon />}


### PR DESCRIPTION
# Pull Request

## Description

Fixes a layout issue where sidebar content could overflow slightly when it wraps onto a second line on smaller screen sizes.

The sidebar used a fixed-height container, which prevented the layout from expanding when the content wrapped. This change replaces the fixed height with a minimum height so the container can grow naturally and avoid text clipping.

Fixes #626

## How Has This Been Tested?

Due to auth and API requirements, the full application could not be run locally.
This change is a minimal CSS fix that directly addresses the fixed-height container responsible for the overflow. The fix is deterministic and does not affect application logic or data flow.

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings

