### PR TITLE
fix: Update broken Wired article link to archive.org version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Head to [quartz.solar](https://quartz.solar) to find out more or to get in touch
 
 ## Solar Electricity Nowcasting UI
 
-The `nowcasting-app` is the repository for [Open Climate Fix](https://openclimatefix.org/)'s solar electricity nowcasting project. See [this great Wired article about OCF's solar electricity forecasting work](https://www.wired.co.uk/article/solar-weather-forecasting) for a good intro to solar electricity nowcasting.
+The `nowcasting-app` is the repository for [Open Climate Fix](https://openclimatefix.org/)'s solar electricity nowcasting project. See [this great Wired article about OCF's solar electricity forecasting work](https://web.archive.org/web/20230330033727/https://www.wired.co.uk/article/solar-weather-forecasting) for a good intro to solar electricity nowcasting.
 
 The plan is to enable the community to build the world's best near-term forecasting system for solar electricity generation, and then let anyone use it! :) We'll do this by using state-of-the-art machine learning and 5-minutely satellite imagery to predict the movement of clouds over the next few hours, and then use this to predict solar electricity generation.
 


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes a broken link in the README. The Wired article about OCF's solar electricity forecasting work was returning a 404 error. The link has been updated to point to a working archived version on the Wayback Machine (archive.org).

Fixes #665

## How Has This Been Tested?

I manually verified that the original link (`https://www.wired.co.uk/article/solar-weather-forecasting`) is down (404) and confirmed that the new archived link (`https://web.archive.org/web/20230330033727/https://www.wired.co.uk/article/solar-weather-forecasting`) loads the article correctly.

- [x] Yes

_If your changes affect data processing, have you plotted any cahanges? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings