### PR TITLE
🚀 Quartz Solar v0.6.5 → Production [reduce /forecast/all data]

### DIFF
--- a/.github/workflows/yarn_test.yaml
+++ b/.github/workflows/yarn_test.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
 #        containers: [1, 2]
 
     steps:
@@ -72,6 +72,7 @@ env:
   NEXT_PUBLIC_AUTH0_SCOPE: ${{ secrets.NEXT_PUBLIC_AUTH0_SCOPE }}
   NEXT_PUBLIC_AUTH0_USERNAME: ${{ secrets.NEXT_PUBLIC_AUTH0_USERNAME }}
   NEXT_PUBLIC_4H_VIEW: 'true'
+  NEXT_PUBLIC_CI: 'true'
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
 

--- a/apps/nowcasting-app/components/charts/delta-view/delta-view-chart.tsx
+++ b/apps/nowcasting-app/components/charts/delta-view/delta-view-chart.tsx
@@ -317,14 +317,7 @@ const DeltaChart: FC<DeltaChartProps> = ({ className, combinedData, combinedErro
   //   }
   // }, [view]);
 
-  if (
-    nationalForecastError ||
-    pvRealDayInError ||
-    pvRealDayAfterError ||
-    nationalNHourError ||
-    allGspForecastError
-  )
-    return <div className={`h-full flex ${className}`}>Failed to load data.</div>;
+  const hasError = Object.entries(combinedErrors).some(([, value]) => value !== null);
 
   if (!nationalForecastData || !pvRealDayInData || !pvRealDayAfterData)
     return (
@@ -352,6 +345,13 @@ const DeltaChart: FC<DeltaChartProps> = ({ className, combinedData, combinedErro
             pvLiveData={pvRealDayInData}
             deltaView={true}
           ></ForecastHeader>
+          {(!nationalForecastData || !pvRealDayInData || !pvRealDayAfterData) && !hasError && (
+            <div
+              className={`h-full absolute flex pb-7 items-center justify-center inset-0 z-30 ${className}`}
+            >
+              <Spinner></Spinner>
+            </div>
+          )}
           <div className={"flex-1 relative"}>
             <DataLoadingChartStatus<NationalEndpointStates> loadingState={loadingState} />
             <RemixLine

--- a/apps/nowcasting-app/components/map/map.tsx
+++ b/apps/nowcasting-app/components/map/map.tsx
@@ -78,6 +78,8 @@ const Map: FC<IMap> = ({
   }, [updateData]);
 
   useEffect(() => {
+    if (process.env.NEXT_PUBLIC_CI === "true") return;
+
     const onMoveEnd = () => {
       console.log("setting map state");
       const currentZoom = map.current?.getZoom() || 0;

--- a/apps/nowcasting-app/components/play-button/index.tsx
+++ b/apps/nowcasting-app/components/play-button/index.tsx
@@ -29,7 +29,7 @@ const PlayButton: React.FC<PlayButtonProps> = ({ endTime, startTime }) => {
         }
         return addMinutesToISODate(selectedISOTime || "", 30);
       });
-    }, 2000);
+    }, 1000);
   };
 
   return (

--- a/apps/nowcasting-app/package.json
+++ b/apps/nowcasting-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclimatefix/nowcasting-app",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",


### PR DESCRIPTION
# Quartz UI Release & UAT

[//]: # (> > [!IMPORTANT])
[//]: # (> > This PR requires updates to the Quartz Solar user documentation.)

[//]: # (> [!WARNING])
[//]: # (> This PR is dependent on the following PRs:)
[//]: # (> - PR[#000])

## Overview

In line with new slimline data platform approach, removing the unnecessarily large data call from initial load in favour of on-demand calls per timestamp.
This should maintain all existing functionality, including past Delta values for the map, and even the "Play Button" actions seem fast enough with the existing data requests not to notice the absence of pre-loading the forecast data.

Fixes #562 

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [x] Locally against dev API
- [x] Vercel Preview: https://nowcasting-app-git-feat-slim-down-2d-fore-b057dd-openclimatefix.vercel.app/
- [x] [Development](https://dev.quartz.solar/)
- [x] [Staging](https://staging.quartz.solar) for the UAT (below)

## Screenshots (if applicable)

N/A

---

# UAT

## Quartz-specific points
- [x] Does the logo look like the new Quartz logo?
- [x] Does the logo link to the new Quartz website?
- [x] Is the OCF logo present in the logo area?
- [x] Does the OCF logo link to the OCF website?
- [x] Does the Documentation link go to the new Quartz docs?


## PV Forecast

### National & GSP Charts (both charts wherever relevant)
- [x] Clicking on a GSP makes the GSP plot show up?
- [x] Clicking on a GSP when already selected, makes the GSP plot go away?
- [x] Does the data look like solar profiles?
- [x] Does PV live estimate show on the plot? (dashed black)
- [x] Does PV live updated show on the plot? (solid black)
- [x] Does OCF forecast show up on plot? (yellow)
- [x] For OCF forecast, is the future a dashed line?
- [x] Can I hover on the plot to show the values on the plot?
- [x] Can I click on a past time in the plot which then updates the map?
- [x] Can I click on a future time in the plot which then updates the map?

#### Headers (Nat & GSP charts)
- [x] Does `National` / the GSP name show up in the header?
- [x] Is the current estimated PV visible?
- [x] Is the next forecast figure visible?
- [x] Are the above figures in GW (National / MW (GSP) respectively?

#### Time (Nat & GSP charts)
- [x] Is time now in Europe London time?
- [x] Is the hover time in Europe London time?
- [x] Are the X axis in Europe London time?
- [x] Does the data show yesterday, today, and tomorrow? 

#### Probabilistic (Nat & GSP charts)
- [x] Shading appears around the lines.
- [x] Plevel values in the tooltip are 0.0 or above.
- [x] Probabilistic range shading and tooltip values appear on the DeltaView charts.

### Map
- [x] Does a map of the UK show up?
- [x] Are the GSP boundaries displayed?
- [x] Can I click on '%', 'MW' and 'Capacity' to show different map shading?
- [x] Are values "higher" on the map in the middle of the day, compared to early morning?
- [x] On 'Capacity' view, is there very little coloured shading in Scotland, and Melksham a shining beacon of renewables?
- [x] Can I click the DNO grouping button and see the regions change on the map?
- [x] If I select a DNO, does the aggregated chart show for that DNO?
- [x] If I have a DNO selected, and click the "GSP" map button, does it deselect the DNO?
- [x] If I have a GSP selected, and click the "DNO" map button, does it deselect the GSP?


## Delta View

### National & GSP Charts (both charts wherever relevant)
- [x] Clicking on a GSP makes the GSP plot show up?
- [x] Clicking on a GSP when already selected, makes the GSP plot go away?
- [x] Does the data look like solar profiles?
- [x] Does PV live estimate show on the plot? (dashed black)
- [x] Does PV live updated show on the plot? (solid black)
- [x] Does OCF forecast show up on plot? (yellow)
- [x] For OCF forecast, is the future a dashed line?
- [x] Can I hover on the plot to show the values on the plot?
- [x] Can I click on a past time in the plot which then updates the map?
- [x] Can I click on a future time in the plot which then updates the map?

#### Headers (Nat & GSP charts)
- [x] Does `National` / the GSP name show up in the header?
- [x] Is the "current" estimated PV visible?
- [x] Is the "current" forecast value visible?
- [x] Is the "next" forecast value visible?
- [x] Are the above figures in GW (National / MW (GSP) respectively?

#### Time (Nat & GSP charts)
- [x] Is time now in Europe London time? It should be now rounded up to the next 30 min.
- [x] Is the hover time in Europe London time?
- [x] Are the X axis in Europe London time?
- [x] Does the data show yesterday, today, and tomorrow?

#### Probabilistic (Nat & GSP charts)
- [x] Shading appears around the lines.
- [x] Plevel values in the tooltip are 0.0 or above.
- [x] Probabilistic range shading and tooltip values appear on the DeltaView charts.

#### Time
- [x] Is time now in Europe London time?
- [x] Is the hover time in Europe London time?
- [x] Are the X axis in Europe London time?

###  Map
- [x] Does a map of the UK show up?
- [x] Are the GSP boundaries displayed?
- [x] Where Deltas are available, do the correct colours for the GSP delta buckets display and match the table?

### Delta GSP Table
- [x] Does the table appear and populate when Delta values are available?
- [x] Does clicking a GSP in the table select the GSP on the map?


## N Hour View

- [x] Does the "N-hour forecast" toggle show in the Profile Dropdown menu?
- Profile Dropdown –> Toggle on
  - [x] Does the Nhr forecast show up on the plot? (orange)
  - [x] Does the Nhr future forecast show up on the plot? (dashed orange)
  - [x] Do the Nhr forecast values show in the hover tooltip?
  - [x] Does the Nhr forecast _not_ show on the charts or tooltips when legend items is switched off?
- Profile Dropdown -> Toggle off
  - [x] Does the Nhr forecast _not_ show on the legend, charts or tooltips when switched off?
  - [x] Does the Nhr hours switcher _not_ show when toggled off?
- [x] Does the Nhr forecast toggle persist across refreshes/logouts using cookie?


## Combined views
- [x] Does **selectedGSP** persist when switching between `PV Forecast` and `Delta` Views
- [x] Does **selectedTime** persist when switching between `PV Forecast` and `Delta` Views
- [x] Does **map location/zoom** persist when switching between `PV Forecast` and `Delta` Views
- [x] If I have a DNO selected, and switch to Delta View, does it deselect?
- [x] When DNO aggregation selected, and I switch to Delta view, can I click a GSP and see its name and data in the chart?


## Dashboard Mode

- [x] Does the `Dashboard Mode` toggle show in the Profile Dropdown menu (top right)?
- [x] Does the `Dashboard Mode` toggle persist across refreshes/logouts using cookie?

### National & GSP
- [x] Do the `National` and `GSP` titles and forecast values show in large font?
- [x] Are the lines on the chart thicker?

### Legend
- [x] Is the legend larger?
- [x] Do the legend items space nicely?

### Map
- [x] Is the map legend larger?
- [x] Are the MW/%/Capacity buttons larger?
- [x] Are the date/time larger?


## General
- [x] Is the version visible in the Profile Dropdown (top right)?
- [x] Has the version been bumped?
- [x] Does the feedback button work?
- [x] Is the legend visible
- [x] Is the database stable, check on AWS

### Auth
- [x] Can I log on with Auth?
- [x] Can I log out?

### Refresh
- [x] After 10 mins, does the forecast update?

### Documentation
- [x] Update documentation - https://openclimatefix.notion.site/Quartz-Solar-Documentation-0d718915650e4f098470d695aa3494bf
- Do we need to email the users
  - [ ] Yes, done
  - [x] No


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the README
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the release docs with the contents of this release
