### PR TITLE
fix: remove NL sites from slicedSitesData

### DIFF
--- a/apps/nowcasting-app/pages/index.tsx
+++ b/apps/nowcasting-app/pages/index.tsx
@@ -595,6 +595,14 @@ export default function Home({ dashboardModeServer }: { dashboardModeServer: str
     () => allSitesData?.site_list.slice(0, 100) || [],
     [allSitesData]
   );
+
+  // Remove NL sites
+  slicedSitesData.forEach((site, index) => {
+    if (site.client_site_name.startsWith("nl_")) {
+      slicedSitesData.splice(index, 1);
+    }
+  });
+
   const siteUuids = slicedSitesData.map((site) => site.site_uuid);
   const siteUuidsString = siteUuids?.join(",") || "";
   const {


### PR DESCRIPTION
# Pull Request

## Description

in sites api filter all the sties whose client_site_name starts with `nl_`

after fix 

<img width="2560" height="871" alt="image" src="https://github.com/user-attachments/assets/660ee1cb-32fb-4cf0-a02f-2119f9455c25" />


Fixes #619 


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
