### PR TITLE
fix[gsp-data]: request only when gsp_ids is set

### DIFF
--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/use-get-gsp-data.ts
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/use-get-gsp-data.ts
@@ -108,9 +108,11 @@ const useGetGspData = (selectedRegions: string[]) => {
     isLoading: pvRealInDayLoading,
     error: pvRealInDayError
   } = useLoadDataFromApi<components["schemas"]["GSPYieldGroupByDatetime"][]>(
-    `${API_PREFIX}/solar/GB/gsp/pvlive/all?regime=in-day&gsp_ids=${encodeURIComponent(
-      selectedGspIds.join(",")
-    )}&compact=true`
+    selectedGspIds.length > 0
+      ? `${API_PREFIX}/solar/GB/gsp/pvlive/all?regime=in-day&gsp_ids=${encodeURIComponent(
+          selectedGspIds.join(",")
+        )}&compact=true`
+      : null
   );
   const pvRealDataIn = aggregateTruthData(pvRealDataInRaw, selectedGspIds, "solarGenerationKw");
 
@@ -119,9 +121,11 @@ const useGetGspData = (selectedRegions: string[]) => {
     isLoading: pvRealDayAfterLoading,
     error: pvRealDayAfterError
   } = useLoadDataFromApi<components["schemas"]["GSPYieldGroupByDatetime"][]>(
-    `${API_PREFIX}/solar/GB/gsp/pvlive/all?regime=day-after&gsp_ids=${encodeURIComponent(
-      selectedGspIds.join(",")
-    )}&compact=true`
+    selectedGspIds.length > 0
+      ? `${API_PREFIX}/solar/GB/gsp/pvlive/all?regime=day-after&gsp_ids=${encodeURIComponent(
+          selectedGspIds.join(",")
+        )}&compact=true`
+      : null
   );
   const pvRealDataAfter = aggregateTruthData(
     pvRealDataAfterRaw,
@@ -135,9 +139,11 @@ const useGetGspData = (selectedRegions: string[]) => {
     isLoading: gspForecastSelectedGSPsLoading,
     error: gspForecastDataOneGSPError
   } = useLoadDataFromApi<components["schemas"]["OneDatetimeManyForecastValues"][]>(
-    `${API_PREFIX}/solar/GB/gsp/forecast/all/?gsp_ids=${encodeURIComponent(
-      selectedGspIds.join(",")
-    )}&compact=true&historic=true&start_datetime_utc=${encodeURIComponent(startDatetime)}`,
+    selectedGspIds.length > 0
+      ? `${API_PREFIX}/solar/GB/gsp/forecast/all/?gsp_ids=${encodeURIComponent(
+          selectedGspIds.join(",")
+        )}&compact=true&historic=true&start_datetime_utc=${encodeURIComponent(startDatetime)}`
+      : null,
     {
       dedupingInterval: 1000 * 30
     }


### PR DESCRIPTION
# Pull Request

## Description

Should skip any API requests getting fired off accidentally without `gsp_ids` param to both `/pvlive/all` and `/forecast/all` routes.

Fixes https://github.com/openclimatefix/client-private/issues/337#issuecomment-4175197680

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [x] Locally with dev API

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
