### PR TITLE
fix: Update timezone from ist to Asia/Kolkata in quartz app

### DIFF
--- a/apps/quartz-app/src/components/Sidebar.tsx
+++ b/apps/quartz-app/src/components/Sidebar.tsx
@@ -52,7 +52,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   const [visibleLines, setVisibleLines] = useGlobalState("visibleLines");
 
   const getNowInTimezone = () => {
-    const now = DateTime.now().setZone("ist");
+    const now = DateTime.now().setZone("Asia/Kolkata");
     return DateTime.fromISO(now.toString().slice(0, 16)).set({
       hour: now.minute >= 45 ? now.hour + 1 : now.hour,
       minute: now.minute < 45 ? Math.floor(now.minute / 15) * 15 : 0,

--- a/apps/quartz-app/src/components/layout/Header.tsx
+++ b/apps/quartz-app/src/components/layout/Header.tsx
@@ -80,7 +80,7 @@ const Header: React.FC<HeaderProps> = () => {
     let csv = csvHeader + csvBody;
     const a = document.createElement("a");
     a.href = URL.createObjectURL(new Blob([csv], { type: "text/csv" }));
-    const now = DateTime.now().setZone("ist");
+    const now = DateTime.now().setZone("Asia/Kolkata");
     const forecastHorizonString = forecastHorizon
       .split("_")
       .map((type) => type.charAt(0).toUpperCase() + type.slice(1))

--- a/apps/quartz-app/src/helpers/datetime.ts
+++ b/apps/quartz-app/src/helpers/datetime.ts
@@ -42,7 +42,7 @@ export const formatEpochToPrettyTime = (time: number) => {
 };
 
 export const getNowInTimezone = () => {
-  const now = DateTime.now().setZone("ist");
+  const now = DateTime.now().setZone("Asia/Kolkata");
   return DateTime.fromISO(now.toString().slice(0, 16)).set({
     hour: now.minute >= 45 ? now.hour + 1 : now.hour,
     minute: now.minute < 45 ? Math.floor(now.minute / 15) * 15 : 0,

--- a/apps/quartz-app/src/hooks/useChartData.test.ts
+++ b/apps/quartz-app/src/hooks/useChartData.test.ts
@@ -60,14 +60,14 @@ describe("useChartData", () => {
     const formattedChartData = useChartData(combinedData);
     expect(formattedChartData).toEqual([
       {
-        timestamp: 1712124000000,
+        timestamp: 1712107800000,
         solar_forecast_past: 0.5,
         solar_generation: 0.5,
         wind_forecast_past: 1,
         wind_generation: 0.5,
       },
       {
-        timestamp: 1712124900000,
+        timestamp: 1712108700000,
         solar_forecast_past: 1,
         solar_generation: 1,
         wind_forecast_past: 2,
@@ -129,21 +129,21 @@ describe("useChartData", () => {
     const formattedChartData = useChartData(combinedData);
     expect(formattedChartData).toEqual([
       {
-        timestamp: 1712124000000,
+        timestamp: 1712107800000,
         solar_forecast_past: 0.5,
         solar_generation: 0.5,
         wind_forecast_past: 1,
         wind_generation: null,
       },
       {
-        timestamp: 1712124900000,
+        timestamp: 1712108700000,
         solar_forecast_past: 1,
         solar_generation: null,
         wind_forecast_past: 2,
         wind_generation: 1,
       },
       {
-        timestamp: 1712125800000,
+        timestamp: 1712109600000,
         solar_forecast_past: 3,
         solar_generation: null,
         wind_forecast_past: 1.5,


### PR DESCRIPTION
# Pull Request

## Description

Root cause was an invalid timezone identifier. Updated to the correct IANA timezone for India (Asia/Kolkata). Also corrected the test data, which was using UK/BST timestamps, and replaced them with IST values.

Fixes #716

## How Has This Been Tested?

Edited the test timestamps to IST and ran jest

<img width="659" height="350" alt="image" src="https://github.com/user-attachments/assets/6e57e080-ac46-48a6-b924-127a834eab87" />

<img width="2553" height="958" alt="image" src="https://github.com/user-attachments/assets/9ef5eda6-e7f1-4faf-b78b-b4e764d374d8" />


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
