### PR TITLE
add celi in yMax to avoid floats in graph

### DIFF
--- a/apps/nowcasting-app/components/charts/solar-site-view/solar-site-chart.tsx
+++ b/apps/nowcasting-app/components/charts/solar-site-view/solar-site-chart.tsx
@@ -101,7 +101,7 @@ const SolarSiteChart: FC<{
     1, 2, 3, 4, 6, 8, 9, 20, 28, 36, 45, 60, 80, 100, 120, 160, 200, 240, 300, 320, 360, 400, 450,
     600
   ];
-  yMax = getRoundedTickBoundary(yMax, yMax_levels);
+  yMax = Math.ceil(getRoundedTickBoundary(yMax, yMax_levels));
 
   const getExpectedPowerGenerationForSite = (site_uuid: string, targetTime: string) => {
     const siteForecast = combinedSitesData.sitesPvForecastData.find(


### PR DESCRIPTION
# Pull Request

## Description

Add celi to yMax this will avoid floats in the graph yMax

Fixes #727 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
