### PR TITLE
Fix[Sites]: timezone drifts in Sites view

### DIFF
--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -15,6 +15,7 @@ import {
 } from "recharts";
 import {
   convertToLocaleDateString,
+  dateToLondonDateTimeString,
   formatISODateStringHumanNumbersOnly,
   getRoundedTickBoundary,
   prettyPrintChartAxisLabelDate,
@@ -800,16 +801,15 @@ const RemixLine: React.FC<RemixLineProps> = ({
 
                 let formattedDate = data?.formattedDate + ":00+00:00";
                 if (view === VIEWS.SOLAR_SITES) {
-                  formattedDate = new Date(Number(data?.formattedDate)).toISOString();
+                  const date = new Date(Number(data?.formattedDate));
+                  formattedDate = dateToLondonDateTimeString(date);
                 }
 
                 return (
                   <div className="px-3 py-2 bg-mapbox-black bg-opacity-80 shadow">
                     <ul className="">
                       <li className={`flex justify-between pb-2 text-xs text-white font-sans`}>
-                        <div className="pr-3">
-                          {formatISODateStringHumanNumbersOnly(formattedDate)}
-                        </div>
+                        <div className="pr-3">{formattedDate}</div>
                         <div>{view === VIEWS.SOLAR_SITES ? "KW" : "MW"}</div>
                       </li>
                       {Object.entries(toolTiplabels)

--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -15,7 +15,6 @@ import {
 } from "recharts";
 import {
   convertToLocaleDateString,
-  dateToLondonDateTimeString,
   formatISODateStringHumanNumbersOnly,
   getRoundedTickBoundary,
   prettyPrintChartAxisLabelDate,
@@ -516,7 +515,11 @@ const RemixLine: React.FC<RemixLineProps> = ({
             )}
 
             <ReferenceLine
-              x={view === VIEWS.SOLAR_SITES ? new Date(currentTime).getTime() : currentTime}
+              x={
+                view === VIEWS.SOLAR_SITES
+                  ? new Date(currentTime + ":00.000Z").getTime()
+                  : currentTime
+              }
               stroke="white"
               strokeWidth={currentTime === timeOfInterest ? 2 : 1}
               yAxisId={"y-axis"}
@@ -797,8 +800,7 @@ const RemixLine: React.FC<RemixLineProps> = ({
 
                 let formattedDate = data?.formattedDate + ":00+00:00";
                 if (view === VIEWS.SOLAR_SITES) {
-                  const date = new Date(Number(data?.formattedDate));
-                  formattedDate = dateToLondonDateTimeString(date);
+                  formattedDate = new Date(Number(data?.formattedDate)).toISOString();
                 }
 
                 return (

--- a/apps/nowcasting-app/components/charts/use-format-chart-data-sites.tsx
+++ b/apps/nowcasting-app/components/charts/use-format-chart-data-sites.tsx
@@ -18,18 +18,14 @@ const getForecastChartData = (
   const generation =
     fr.expected_generation_kw > 20 ? fr.expected_generation_kw / 7000 : fr.expected_generation_kw;
 
-  if (new Date(fr.target_datetime_utc).getTime() > new Date(timeNow + ":00.000Z").getTime())
-    return {
-      [futureKey]: generation
-    };
-  else if (new Date(fr.target_datetime_utc).getTime() === new Date(timeNow + ":00.000Z").getTime())
-    return {
-      [futureKey]: generation
-    };
-  else
-    return {
-      [pastKey]: generation
-    };
+  const targetEpoch = new Date(
+    fr.target_datetime_utc.endsWith("Z") ? fr.target_datetime_utc : fr.target_datetime_utc + "Z"
+  ).getTime();
+  const timeNowEpoch = new Date(timeNow + ":00.000Z").getTime();
+
+  if (targetEpoch > timeNowEpoch) return { [futureKey]: generation };
+  else if (targetEpoch === timeNowEpoch) return { [futureKey]: generation };
+  else return { [pastKey]: generation };
 };
 // const getDelta: (datum: ChartData) => number = (datum) => {
 //   if (datum.PAST_FORECAST !== undefined) {
@@ -84,7 +80,11 @@ const useFormatChartDataSites = ({
         const formattedDate = getDatetimeUtc(dataPoint);
         if (!chartMap[formattedDate]) {
           chartMap[formattedDate] = {
-            formattedDate: new Date(formattedDate).getTime().toString(),
+            formattedDate: new Date(
+              formattedDate.endsWith("Z") ? formattedDate : formattedDate + "Z"
+            )
+              .getTime()
+              .toString(),
             ...sitePvData
           };
         } else {

--- a/apps/nowcasting-app/components/charts/use-format-chart-data-sites.tsx
+++ b/apps/nowcasting-app/components/charts/use-format-chart-data-sites.tsx
@@ -84,7 +84,7 @@ const useFormatChartDataSites = ({
         const formattedDate = getDatetimeUtc(dataPoint);
         if (!chartMap[formattedDate]) {
           chartMap[formattedDate] = {
-            formattedDate: new Date(convertToLocaleDateString(formattedDate)).getTime().toString(),
+            formattedDate: new Date(formattedDate).getTime().toString(),
             ...sitePvData
           };
         } else {


### PR DESCRIPTION
# Pull Request

## Description


In ref line added `:00.000Z` this prevent the ref line to switch back 5:30Hrs when a current time is changed 

remove `convertToLocaleDateString` as date is already in UTC


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
