### PR TITLE
hotfix[csv]: set dates by end; local time for filename

### DIFF
--- a/apps/nowcasting-app/components/helpers/csvDownload.ts
+++ b/apps/nowcasting-app/components/helpers/csvDownload.ts
@@ -43,8 +43,8 @@ const getColumnConfig = (
 });
 
 const createEmptyRow = (timestamp: string): CSVRow => {
-  const start = DateTime.fromISO(timestamp);
-  const end = start.plus({ minutes: 30 });
+  const end = DateTime.fromISO(timestamp);
+  const start = end.minus({ minutes: 30 });
   const settlementPeriod = getSettlementPeriodForDate(start);
 
   return {
@@ -129,8 +129,8 @@ export const downloadNationalCsv = (
   const a = document.createElement("a");
   a.href = url;
 
-  const now = DateTime.now().toUTC().toFormat("yyyy-MM-dd_HH-mm");
-  a.download = `Quartz-National-${now}.csv`;
+  const now = DateTime.now().toLocal().toFormat("yyyy-MM-dd_HH-mm-ssZZZ");
+  a.download = `Quartz_National_${now}.csv`;
 
   document.body.appendChild(a);
   a.click();


### PR DESCRIPTION
# Pull Request

## Description

Fix for CSV timestamps mismatch, should correct start/end times and settlement periods in relation to data as seen in UI.

N.B. the CSV datestamps are given in UK time, as seen on the UI.

Fixes #

## How Has This Been Tested?

- [x] Locally

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
