### PR TITLE
add condition to handle when GENERATION is not there

### DIFF
--- a/apps/nowcasting-app/components/charts/use-format-chart-data.tsx
+++ b/apps/nowcasting-app/components/charts/use-format-chart-data.tsx
@@ -51,6 +51,8 @@ const getDelta: (datum: ChartData) => number = (datum) => {
       return Number(datum.GENERATION_UPDATED) - Number(datum.PAST_FORECAST);
     } else if (datum.GENERATION !== undefined) {
       return Number(datum.GENERATION) - Number(datum.PAST_FORECAST);
+    } else if (datum.FORECAST !== undefined && datum["N_HOUR_FORECAST"] !== undefined) {
+      return Number(datum.FORECAST) - Number(datum["N_HOUR_FORECAST"]);
     }
   } else if (datum.FORECAST !== undefined && datum["N_HOUR_FORECAST"] !== undefined) {
     return Number(datum.FORECAST) - Number(datum["N_HOUR_FORECAST"]);


### PR DESCRIPTION
# Pull Request

## Description


Before fix

<img width="1281" height="527" alt="image" src="https://github.com/user-attachments/assets/7dcffed7-3780-4376-baac-6fc4564ddeca" />



After fix

<img width="1281" height="527" alt="image" src="https://github.com/user-attachments/assets/21fb4bb8-00bd-4560-a455-0f7298a4cfd2" />

add fallback condition to show delta between N-Hour and current, in the case of `now` the `PAST_FORECAST` and `FORECAST` are set to same value to maintain continuity in graph  Ref - #88

Fixes #737 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
