### PR TITLE
fix(zoom): reset zoom area on zoom out

### DIFF
--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -263,6 +263,7 @@ const RemixLine: React.FC<RemixLineProps> = ({
 
   //reset zoom state
   function handleZoomOut() {
+    setGlobalZoomArea({ x1: "", x2: "" });
     setGlobalIsZoomed(false);
     setFilteredPreppedData(preppedData);
   }


### PR DESCRIPTION
# Pull Request

## Description

https://github.com/user-attachments/assets/e0ed597e-9236-4918-a3f4-bfc5cc0bb051

The issue occurred because the reset zoom function was not clearing the global zoom area variables.

When a user zooms in, those values remain stored. Later, when they click Live, it triggers resetTime, which causes the chart to re-render. Since the zoom variables were never reset, the previous zoom range gets applied again to the graph.

Fixes #742 


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
