### PR TITLE
fix: show error message if webGL is not supported

### DIFF
--- a/apps/nowcasting-app/components/map/map.tsx
+++ b/apps/nowcasting-app/components/map/map.tsx
@@ -63,6 +63,7 @@ const Map: FC<IMap> = ({
   const [currentAggregation, setAggregation] = useGlobalState("aggregationLevel");
   const [autoZoom] = useGlobalState("autoZoom");
   const resetButtonDiv = useRef<HTMLDivElement | null>(null);
+  const [webGlSupported, setWebGlSupported] = useState<boolean>(true);
 
   // Keep the latest autoZoom value available inside Mapbox event handlers (avoid stale closures)
   const autozoomRef = useRef(autoZoom);
@@ -81,6 +82,12 @@ const Map: FC<IMap> = ({
 
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_CI === "true") return;
+
+    // check if webgl is supported
+    if (!mapboxgl.supported()) {
+      setWebGlSupported(false);
+      return;
+    }
 
     const onMoveEnd = () => {
       console.log("setting map state");
@@ -176,6 +183,20 @@ const Map: FC<IMap> = ({
       }
     };
   }, []);
+
+  if (!webGlSupported) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-ocf-black-500 p-6 text-center">
+        <div>
+          <h3 className="text-lg font-semibold text-ocf-yellow">Map Unavailable</h3>
+          <p className="mt-2 text-sm text-ocf-gray-600">
+            Your browser does not support WebGL, which is required to display the map. <br />
+            Please update your browser or use the latest version of Chrome.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="relative h-full overflow-hidden bg-ocf-gray-900">


### PR DESCRIPTION
# Pull Request

## Description

Adds a graceful fallback for browsers that do not support WebGL.

Previously, users encountered a client-side application error when WebGL was unavailable. This change detects the lack of WebGL support and displays a user-friendly message instead, preventing the application from crashing.

<img width="2560" height="960" alt="image" src="https://github.com/user-attachments/assets/866fe17c-f7da-4e2e-b960-3e9488bbbb27" />


Fixes #752 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
