### PR TITLE
feat: debounce map loading spinner to avoid flash on cached timesteps

### DIFF
--- a/apps/nowcasting-app/components/map/pvLatestMap.tsx
+++ b/apps/nowcasting-app/components/map/pvLatestMap.tsx
@@ -497,13 +497,27 @@ const PvLatestMap: React.FC<PvLatestMapProps> = ({
     };
   }, [mapDataLoading]);
 
+  // Debounce the spinner so it only shows for data loads, not the brief
+  // mapDataLoading rerender that happens when flipping between already-cached
+  // timesteps. If loading resolves within the threshold (cached re-render),
+  // the spinner never appears.
+  const isLoading =
+    !combinedData.allGspForecastData || combinedLoading.allGspForecastLoading || mapDataLoading;
+  const [showSpinner, setShowSpinner] = useState(false);
+  useEffect(() => {
+    if (!isLoading) {
+      setShowSpinner(false);
+      return;
+    }
+    const t = setTimeout(() => setShowSpinner(true), 700);
+    return () => clearTimeout(t);
+  }, [isLoading]);
+
   return (
     <div className={`pv-map relative h-full w-full ${className}`}>
       {
         <>
-          {(!combinedData.allGspForecastData ||
-            combinedLoading.allGspForecastLoading ||
-            mapDataLoading) && (
+          {showSpinner && (
             <LoadStateMap>
               <Spinner />
             </LoadStateMap>


### PR DESCRIPTION
  # Pull Request

  ## Description
  
Debounce the forecast map loading spinner so it only appears for genuine loads, not the brief flicker when flipping between already-cached timesteps.

Set a single isLoading boolean and gate the spinner behind a debounced showSpinner state that only turns on after loading persists for 700ms. Cached re-renders resolve well within that window so the spinner never shows; genuine network loads still surface it. Timer is cleared whenever loading resolves, preventing a stale flash. Existing 3s mapDataLoading safety timeout left untouched as a backstop.

Fixes #754
  
  ## How Has This Been Tested?

  - [x] Locally

  ## Checklist:

  - [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
  - [x] I have performed a self-review of my own code
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] I have checked my code and corrected any misspellings
