### PR TITLE
chore: change Sentry log level from 'log' to 'info' for CSV download  and disable download till data is loaded 

### DIFF
--- a/apps/quartz-app/src/components/Main.tsx
+++ b/apps/quartz-app/src/components/Main.tsx
@@ -13,6 +13,7 @@ import { useEffect, useMemo } from "react";
 
 export const Main = () => {
   const [combinedData, setCombinedData] = useGlobalState("combinedData");
+  const [, setIsLoading] = useGlobalState("isLoading");
   const [forecastHorizon] = useGlobalState("forecastHorizon");
   const [forecastHorizonMinutes] = useGlobalState("forecastHorizonMinutes");
 
@@ -107,6 +108,10 @@ export const Main = () => {
     solarRegionsLoading,
     windRegionsLoading,
   ]);
+
+  useEffect(() => {
+    setIsLoading(isLoading);
+  }, [setIsLoading, isLoading]);
 
   if (
     solarRegionsError ||

--- a/apps/quartz-app/src/components/helpers/globalState.tsx
+++ b/apps/quartz-app/src/components/helpers/globalState.tsx
@@ -7,6 +7,7 @@ import { components } from "@/src/types/schema";
 export type GlobalStateType = {
   visibleLines: string[];
   combinedData: CombinedData;
+  isLoading: boolean;
   forecastHorizon: components["schemas"]["ForecastHorizon"];
   forecastHorizonMinutes: number;
 };
@@ -42,6 +43,7 @@ export const {
 > = createGlobalState<GlobalStateType>({
   visibleLines: ["Solar", "Wind"],
   combinedData: {} as CombinedData,
+  isLoading: true,
   forecastHorizon: "latest",
   forecastHorizonMinutes: 90,
 });

--- a/apps/quartz-app/src/components/layout/Header.tsx
+++ b/apps/quartz-app/src/components/layout/Header.tsx
@@ -94,7 +94,7 @@ const Header: React.FC<HeaderProps> = () => {
       .replaceAll("T", "_")}.csv`;
     Sentry.captureEvent({
       message: "Downloaded CSV",
-      level: "log",
+      level: "info",
       tags: {
         forecastHorizon: `${forecastHorizon}${forecastHorizonTimeString}`,
       },

--- a/apps/quartz-app/src/components/layout/Header.tsx
+++ b/apps/quartz-app/src/components/layout/Header.tsx
@@ -14,6 +14,7 @@ type HeaderProps = {};
 const Header: React.FC<HeaderProps> = () => {
   const { showUserMenu, setShowUserMenu } = useUserMenu();
   const [combinedData] = useGlobalState("combinedData");
+  const [isLoading] = useGlobalState("isLoading");
   const [forecastHorizon] = useGlobalState("forecastHorizon");
   const [forecastHorizonMinutes] = useGlobalState("forecastHorizonMinutes");
   const { user } = useUser();
@@ -150,9 +151,10 @@ const Header: React.FC<HeaderProps> = () => {
             <>
               <button
                 id="DownloadCsvButton"
-                className="text-sm p-2"
+                className={`text-sm p-2 ${isLoading ? "opacity-40 cursor-not-allowed" : ""}`}
                 title={"Download CSV"}
                 tabIndex={0}
+                disabled={isLoading}
                 onClick={downloadCsv}
               >
                 <DownloadIcon />

--- a/apps/quartz-app/src/components/layout/Header.tsx
+++ b/apps/quartz-app/src/components/layout/Header.tsx
@@ -151,7 +151,9 @@ const Header: React.FC<HeaderProps> = () => {
             <>
               <button
                 id="DownloadCsvButton"
-                className={`text-sm p-2 ${isLoading ? "opacity-40 cursor-not-allowed" : ""}`}
+                className={`text-sm p-2 ${
+                  isLoading ? "opacity-40 cursor-not-allowed" : ""
+                }`}
                 title={"Download CSV"}
                 tabIndex={0}
                 disabled={isLoading}


### PR DESCRIPTION
# Pull Request

## Description

Fix issue if the user tries to download CSV in Quartz app before the data is loaded we get a sentry error 
and 
change Sentry log level from 'log' to 'info' for CSV download event

<img width="695" height="369" alt="image" src="https://github.com/user-attachments/assets/2944a4cd-4b51-44c6-9625-5e9b9e643d4e" />


Ref - #583

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
