### PR TITLE
fix: gap in the now point in NL charts

### DIFF
--- a/apps/nowcasting-app/components/charts/NLNationalChart.tsx
+++ b/apps/nowcasting-app/components/charts/NLNationalChart.tsx
@@ -53,19 +53,23 @@ const NLNationalChart: React.FC<{
 
     nlForecastData?.values.forEach((fv) => {
       const isAfterNow = fv.time_utc.slice(0, 16) >= (timeNowFormatted || "");
+      const isNow = fv.time_utc.slice(0, 16) === (timeNowFormatted || "");
       chartMap[fv.time_utc] = {
         ...chartMap[fv.time_utc],
         formattedDate: formatISODateString(fv.time_utc) || "",
-        [isAfterNow ? "FORECAST" : "PAST_FORECAST"]: fv.power_kW / 1000
+        [isAfterNow ? "FORECAST" : "PAST_FORECAST"]: fv.power_kW / 1000,
+        ...(isNow && { PAST_FORECAST: fv.power_kW / 1000 })
       };
     });
 
     nlUncurtailedForecastData?.values.forEach((fv) => {
       const isAfterNow = fv.time_utc.slice(0, 16) >= (timeNowFormatted || "");
+      const isNow = fv.time_utc.slice(0, 16) === (timeNowFormatted || "");
       chartMap[fv.time_utc] = {
         ...chartMap[fv.time_utc],
         formattedDate: formatISODateString(fv.time_utc) || "",
-        [isAfterNow ? "NL_UNCURTAILED" : "PAST_NL_UNCURTAILED"]: fv.power_kW / 1000
+        [isAfterNow ? "NL_UNCURTAILED" : "PAST_NL_UNCURTAILED"]: fv.power_kW / 1000,
+        ...(isNow && { PAST_NL_UNCURTAILED: fv.power_kW / 1000 })
       };
     });
 

--- a/apps/nowcasting-app/components/charts/NLRegionalChart.tsx
+++ b/apps/nowcasting-app/components/charts/NLRegionalChart.tsx
@@ -82,19 +82,23 @@ const NLRegionalChart: React.FC<{
 
     blendForecastData?.values.forEach((fv) => {
       const isAfterNow = fv.time_utc.slice(0, 16) >= (timeNowFormatted || "");
+      const isNow = fv.time_utc.slice(0, 16) === (timeNowFormatted || "");
       chartMap[fv.time_utc] = {
         ...chartMap[fv.time_utc],
         formattedDate: formatISODateString(fv.time_utc) || "",
-        [isAfterNow ? "FORECAST" : "PAST_FORECAST"]: fv.power_kW / 1000
+        [isAfterNow ? "FORECAST" : "PAST_FORECAST"]: fv.power_kW / 1000,
+        ...(isNow && { PAST_FORECAST: fv.power_kW / 1000 })
       };
     });
 
     uncurtailedForecastData?.values.forEach((fv) => {
       const isAfterNow = fv.time_utc.slice(0, 16) >= (timeNowFormatted || "");
+      const isNow = fv.time_utc.slice(0, 16) === (timeNowFormatted || "");
       chartMap[fv.time_utc] = {
         ...chartMap[fv.time_utc],
         formattedDate: formatISODateString(fv.time_utc) || "",
-        [isAfterNow ? "NL_UNCURTAILED" : "PAST_NL_UNCURTAILED"]: fv.power_kW / 1000
+        [isAfterNow ? "NL_UNCURTAILED" : "PAST_NL_UNCURTAILED"]: fv.power_kW / 1000,
+        ...(isNow && { PAST_NL_UNCURTAILED: fv.power_kW / 1000 })
       };
     });
 


### PR DESCRIPTION
# Pull Request

## Description

Fixes the gap in NL charts, it is due to missing connector timestamp in now pint,  in UK, on the now point we have ` [futureKey]: value, [pastKey]: value` on now point  but in NL we use a ternary opp, so it is missing the connection timestamp and the graph default behavior is `connectNulls = false`

<img width="2560" height="964" alt="image" src="https://github.com/user-attachments/assets/10980991-8585-40a5-865e-4dd6fcf18aa6" />

## How Has This Been Tested?

- [x] Locally 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
