### PR TITLE
fix: query gsp actuals at selected time so map tooltip matches

### DIFF
--- a/apps/nowcasting-app/pages/index.tsx
+++ b/apps/nowcasting-app/pages/index.tsx
@@ -389,9 +389,9 @@ export default function Home({ dashboardModeServer }: { dashboardModeServer: str
     isValidating: allGspActualHistoricValidating,
     error: allGspActualHistoricError
   } = useLoadDataFromApi<components["schemas"]["GSPYieldGroupByDatetime"][]>(
-    `${API_PREFIX}/solar/GB/gsp/pvlive/all?compact=true&end_datetime_utc=${encodeURIComponent(
-      `${actualsLastFetch30MinISO.slice(0, 19)}+00:00`
-    )}`,
+    `${API_PREFIX}/solar/GB/gsp/pvlive/all?compact=true&start_datetime_utc=${encodeURIComponent(
+      `${selectedISOTime.slice(0, 19)}+00:00`
+    )}&end_datetime_utc=${encodeURIComponent(`${selectedISOTime.slice(0, 19)}+00:00`)}`,
     {
       refreshInterval: 0, // Only load this once at beginning
       onSuccess: (data) => {


### PR DESCRIPTION
# Pull Request

## Description

The GSP actuals used by the map tooltip were fetched with only an `end_datetime_utc`, anchored on `actualsLastFetch30MinISO` (the time of the last fetch) rather than on the timestep the user has selected. Selecting any time where there should be actuals left the tooltip in the map without an actuals value for any of the GSP regions.

Query the endpoint for the selected timestep instead, passing `selectedISOTime` as both `start_datetime_utc` and `end_datetime_utc` so it returns the single settlement period being viewed.

```diff
-  `${API_PREFIX}/solar/GB/gsp/pvlive/all?compact=true&end_datetime_utc=${encodeURIComponent(
-    `${actualsLastFetch30MinISO.slice(0, 19)}+00:00`
-  )}`,
+  `${API_PREFIX}/solar/GB/gsp/pvlive/all?compact=true&start_datetime_utc=${encodeURIComponent(
+    `${selectedISOTime.slice(0, 19)}+00:00`
+  )}&end_datetime_utc=${encodeURIComponent(`${selectedISOTime.slice(0, 19)}+00:00`)}`,
```

`actualsLastFetch30MinISO` is still used elsewhere in the file, so it is left in place.

## How Has This Been Tested?

- [x] Locally

`tsc --noEmit`, `next lint` and `prettier --check` all good. 
The two `react-hooks/exhaustive-deps` warnings reported by lint are pre-existing and on unrelated lines.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
