### PR TITLE
fix: render missing chart values as gaps rather than joining them up

### DIFF
--- a/apps/quartz-app/jest.config.ts
+++ b/apps/quartz-app/jest.config.ts
@@ -6,6 +6,18 @@
 import type { Config } from "jest";
 import nextJest from "next/jest";
 
+// `convertDatestampToEpoch` strips the offset off the API's timestamps and lets
+// `new Date` reinterpret the wall clock in the runner's local zone, so every
+// epoch this app computes depends on the machine's timezone. Expected values in
+// useChartData.test.ts were therefore only correct on a machine set to IST, and
+// the suite failed everywhere else.
+//
+// Pin the zone so results are reproducible regardless of where the tests run.
+// This is set here rather than in `setupFiles` because jest.config.ts is
+// evaluated in the parent process before the workers fork, so they inherit it at
+// startup — after Node has cached the zone it is too late to change it.
+process.env.TZ = "Asia/Kolkata";
+
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
   dir: "./",

--- a/apps/quartz-app/src/components/Sidebar.tsx
+++ b/apps/quartz-app/src/components/Sidebar.tsx
@@ -20,6 +20,7 @@ import MiniCard from "./sidebar-components/mini-card";
 import { DateTime } from "luxon";
 import { FC } from "react";
 import { get } from "http";
+import { KWtoMW } from "@/src/helpers/formatHelpers";
 
 type SidebarProps = {
   title: string;
@@ -85,10 +86,10 @@ const Sidebar: React.FC<SidebarProps> = ({
   let formattedSidebarData: {
     timestamp: number;
     time?: string;
-    solar_forecast?: number;
-    wind_forecast?: number;
-    solar_generation?: number;
-    wind_generation?: number;
+    solar_forecast?: number | null;
+    wind_forecast?: number | null;
+    solar_generation?: number | null;
+    wind_generation?: number | null;
   }[] = [];
 
   if (windForecastData?.values) {
@@ -96,11 +97,11 @@ const Sidebar: React.FC<SidebarProps> = ({
       const timestamp = convertDatestampToEpoch(value.Time);
       const existingData = formattedSidebarData?.find((data) => data.timestamp === timestamp);
       if (existingData) {
-        existingData.wind_forecast = value.PowerKW / 1000;
+        existingData.wind_forecast = KWtoMW(value.PowerKW);
       } else {
         formattedSidebarData.push({
           timestamp,
-          wind_forecast: value.PowerKW / 1000
+          wind_forecast: KWtoMW(value.PowerKW)
         });
       }
     }
@@ -113,12 +114,12 @@ const Sidebar: React.FC<SidebarProps> = ({
       const timestamp = convertDatestampToEpoch(value.Time);
       const existingData = formattedSidebarData?.find((data) => data.timestamp === timestamp);
       if (existingData) {
-        existingData.solar_forecast = value.PowerKW / 1000;
+        existingData.solar_forecast = KWtoMW(value.PowerKW);
       } else {
         formattedSidebarData.push({
           timestamp,
           time,
-          solar_forecast: value.PowerKW / 1000
+          solar_forecast: KWtoMW(value.PowerKW)
         });
       }
     }
@@ -129,7 +130,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       const timestamp = convertDatestampToEpoch(value.Time);
       const existingData = formattedSidebarData?.find((data) => data.timestamp === timestamp);
       if (existingData && (existingData.solar_forecast || existingData.wind_forecast)) {
-        existingData.solar_generation = value.PowerKW / 1000;
+        existingData.solar_generation = KWtoMW(value.PowerKW);
       }
     }
   }
@@ -139,7 +140,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       const timestamp = convertDatestampToEpoch(value.Time);
       const existingData = formattedSidebarData?.find((data) => data.timestamp === timestamp);
       if (existingData && (existingData.solar_forecast || existingData.wind_forecast)) {
-        existingData.wind_generation = value.PowerKW / 1000;
+        existingData.wind_generation = KWtoMW(value.PowerKW);
       }
     }
   }

--- a/apps/quartz-app/src/components/layout/Header.tsx
+++ b/apps/quartz-app/src/components/layout/Header.tsx
@@ -5,7 +5,7 @@ import { useUserMenu } from "@/src/hooks/useUserMenu";
 import useGlobalState from "../helpers/globalState";
 import { DownloadIcon } from "@/src/components/icons/icons";
 import { DateTime } from "luxon";
-import { KWtoMW } from "@/src/helpers/dataFormats";
+import { KWtoMW } from "@/src/helpers/formatHelpers";
 import { useUser } from "@auth0/nextjs-auth0/client";
 import * as Sentry from "@sentry/nextjs";
 
@@ -53,15 +53,13 @@ const Header: React.FC<HeaderProps> = () => {
           if (!value.Time) continue;
           const existingEntry = combinedDataByTimestampMap.get(value.Time);
           if (existingEntry) {
-            existingEntry[type as keyof typeof combinedData] = value.PowerKW
-              ? KWtoMW(value.PowerKW, 2)
-              : null;
+            existingEntry[type as keyof typeof combinedData] = KWtoMW(value.PowerKW, 2);
             combinedDataByTimestampMap.set(value.Time, existingEntry);
           } else {
             combinedDataByTimestampMap.set(value.Time, {
               time: value.Time,
               ...csvProperties,
-              [type]: value.PowerKW ? KWtoMW(value.PowerKW, 2) : null
+              [type]: KWtoMW(value.PowerKW, 2)
             });
           }
         }

--- a/apps/quartz-app/src/helpers/dataFormats.ts
+++ b/apps/quartz-app/src/helpers/dataFormats.ts
@@ -1,5 +1,0 @@
-export const KWtoMW = (KW: number, decimalPlaces?: number) => {
-  if (decimalPlaces) return Number((Number(KW) / 1000).toFixed(decimalPlaces));
-
-  return Number(KW) / 1000;
-};

--- a/apps/quartz-app/src/helpers/formatHelpers.ts
+++ b/apps/quartz-app/src/helpers/formatHelpers.ts
@@ -1,0 +1,18 @@
+// Missing values should be written as null, not 0 or NaN. Downstream consumers
+// (e.g. Recharts, whose connectNulls defaults to false) distinguish a real 0
+// reading from a genuinely absent one, and treating them the same is wrong in
+// both directions: raw `null / 1000` is 0 in JS (a fake reading that hides a
+// gap) and `undefined / 1000` is NaN.
+//
+// Hence `!= null` rather than a truthy check: 0 is a legitimate reading (e.g.
+// solar overnight) and must stay 0, while only genuinely absent values become
+// null. A truthy check conflates the two.
+export const KWtoMW = (
+  powerKW: number | null | undefined,
+  decimalPlaces?: number
+): number | null => {
+  if (powerKW == null) return null;
+
+  const MW = Number(powerKW) / 1000;
+  return decimalPlaces != null ? Number(MW.toFixed(decimalPlaces)) : MW;
+};

--- a/apps/quartz-app/src/hooks/useChartData.ts
+++ b/apps/quartz-app/src/hooks/useChartData.ts
@@ -1,6 +1,21 @@
 import { ChartDatum, CombinedData } from "@/src/types/data";
 import { convertDatestampToEpoch, getEpochNowInTimezone } from "@/src/helpers/datetime";
 
+// Missing values are written as null, which Recharts renders as a real break in
+// the line (connectNulls defaults to false). Any number — including 0 — is a data
+// point it will draw and join to its neighbours, so a missing reading written as
+// 0 bridges the gap instead of showing one.
+//
+// Hence `!= null` rather than a truthy check: 0 is a legitimate reading (solar
+// overnight) and must stay 0, while only genuinely absent values become null.
+// A truthy check conflates the two and turns real zeros into gaps.
+//
+// Note the raw arithmetic this replaces was wrong in both directions: `null /
+// 1000` is 0 in JS (a fake reading that bridges the gap) and `undefined / 1000`
+// is NaN.
+const toMW = (powerKW: number | null | undefined): number | null =>
+  powerKW != null ? powerKW / 1000 : null;
+
 export const useChartData = (combinedData: CombinedData) => {
   let formattedChartData: ChartDatum[] = [];
 
@@ -15,19 +30,19 @@ export const useChartData = (combinedData: CombinedData) => {
       // so that the area chart doesn't have a gap
       const isNowEntry = timestamp === getEpochNowInTimezone();
       if (existingData) {
-        existingData[key] = value.PowerKW ? value.PowerKW / 1000 : null;
+        existingData[key] = toMW(value.PowerKW);
         if (isNowEntry) {
-          existingData["wind_forecast_future"] = value.PowerKW ? value.PowerKW / 1000 : null;
+          existingData["wind_forecast_future"] = toMW(value.PowerKW);
         }
       } else {
         const newEntry = {
           timestamp,
-          [key]: value.PowerKW / 1000,
+          [key]: toMW(value.PowerKW),
           solar_generation: null,
           wind_generation: null
         };
         if (isNowEntry) {
-          newEntry["wind_forecast_future"] = value.PowerKW / 1000;
+          newEntry["wind_forecast_future"] = toMW(value.PowerKW);
         }
         formattedChartData?.push(newEntry);
       }
@@ -44,19 +59,19 @@ export const useChartData = (combinedData: CombinedData) => {
       // so that the area chart doesn't have a gap
       const isNowEntry = timestamp === getEpochNowInTimezone();
       if (existingData) {
-        existingData[key] = value.PowerKW ? value.PowerKW / 1000 : 0;
+        existingData[key] = toMW(value.PowerKW);
         if (isNowEntry) {
-          existingData["solar_forecast_future"] = value.PowerKW ? value.PowerKW / 1000 : null;
+          existingData["solar_forecast_future"] = toMW(value.PowerKW);
         }
       } else {
         const newEntry = {
           timestamp,
-          [key]: value.PowerKW / 1000,
+          [key]: toMW(value.PowerKW),
           solar_generation: null,
           wind_generation: null
         };
         if (isNowEntry) {
-          newEntry["solar_forecast_future"] = value.PowerKW / 1000;
+          newEntry["solar_forecast_future"] = toMW(value.PowerKW);
         }
         formattedChartData?.push(newEntry);
       }
@@ -75,7 +90,7 @@ export const useChartData = (combinedData: CombinedData) => {
           existingData.wind_forecast_future ||
           existingData.wind_forecast_past)
       ) {
-        existingData.solar_generation = value.PowerKW / 1000;
+        existingData.solar_generation = toMW(value.PowerKW);
       }
     }
   }
@@ -92,7 +107,7 @@ export const useChartData = (combinedData: CombinedData) => {
           existingData.wind_forecast_future ||
           existingData.wind_forecast_past)
       ) {
-        existingData.wind_generation = value.PowerKW / 1000;
+        existingData.wind_generation = toMW(value.PowerKW);
       }
     }
   }

--- a/apps/quartz-app/src/hooks/useChartData.ts
+++ b/apps/quartz-app/src/hooks/useChartData.ts
@@ -1,20 +1,6 @@
 import { ChartDatum, CombinedData } from "@/src/types/data";
 import { convertDatestampToEpoch, getEpochNowInTimezone } from "@/src/helpers/datetime";
-
-// Missing values are written as null, which Recharts renders as a real break in
-// the line (connectNulls defaults to false). Any number — including 0 — is a data
-// point it will draw and join to its neighbours, so a missing reading written as
-// 0 bridges the gap instead of showing one.
-//
-// Hence `!= null` rather than a truthy check: 0 is a legitimate reading (solar
-// overnight) and must stay 0, while only genuinely absent values become null.
-// A truthy check conflates the two and turns real zeros into gaps.
-//
-// Note the raw arithmetic this replaces was wrong in both directions: `null /
-// 1000` is 0 in JS (a fake reading that bridges the gap) and `undefined / 1000`
-// is NaN.
-const toMW = (powerKW: number | null | undefined): number | null =>
-  powerKW != null ? powerKW / 1000 : null;
+import { KWtoMW as toMW } from "@/src/helpers/formatHelpers";
 
 export const useChartData = (combinedData: CombinedData) => {
   let formattedChartData: ChartDatum[] = [];


### PR DESCRIPTION
# Pull Request

## Description

Missing values in the quartz-app chart were being drawn as a continuous line instead of a gap, which looks like real predicted generation — most misleadingly heading into nighttime, where it looks like there is lingering PV.

Recharts only breaks a line on `null` (`connectNulls` defaults to `false`). Any number, including `0`, is a data point it will draw and join to its neighbours. `useChartData` was producing numbers where it should have produced `null`:

```js
// existing-entry path — a falsy check, so a real 0 and a missing reading are treated alike
existingData[key] = value.PowerKW ? value.PowerKW / 1000 : 0;    // solar past
existingData[key] = value.PowerKW ? value.PowerKW / 1000 : null; // everything else

// new-entry path — no guard at all
[key]: value.PowerKW / 1000,
```

Two distinct bugs:

1. **The falsy check conflates "zero" with "missing".** Solar overnight is legitimately `0` kW, and `0` is falsy, so genuine zeros took the same branch as absent readings. Solar-past then wrote `0` for both — bridging the gap — while every other series wrote `null`, turning real zeros into gaps.

2. **The new-entry path had no guard.** In JS `null / 1000` is `0` and `undefined / 1000` is `NaN`. This is the branch taken the first time a timestamp is seen — and since wind forecast is the first loop over an empty array, **every wind value went through it**. The guarded branch was effectively only reached by solar.

Both now go through one helper:

```ts
const toMW = (powerKW: number | null | undefined): number | null =>
  powerKW != null ? powerKW / 1000 : null;
```

`!= null` rather than a truthy check, so `0` stays `0` and only genuinely absent readings become `null`. Applied to all ten conversions — forecast and generation, both branches.

| `PowerKW` | before | after |
|---|---|---|
| `1000` | `1` | `1` |
| `0` (overnight) | `null` → gap, or `0` on solar-past | `0` → sits on the axis |
| `null` | `0` on solar-past / new entries → bridges gap | `null` → gap |
| `undefined` | `NaN` on new entries | `null` → gap |

### Second commit: pin the jest timezone

`useChartData.test.ts` had 2 of 4 tests failing on `development` before this branch. The expected epochs were only correct on a machine set to IST.

Root cause is in production code, not the test. `convertDatestampToEpoch` does:

```ts
const date = new Date(time.slice(0, 16));
```

`slice(0, 16)` drops the `+05:30` offset, and a date-time string without an offset is parsed as **local** time — so every epoch the app computes depends on the runner's timezone. The app then formats with `DateTime.fromMillis` (also local), so it round-trips and the IST wall clock displays correctly for any viewer. Fragile, but internally consistent, so this PR does not change it.

The test expectations were previously corrected to whatever a machine in IST produced, which fixed them there and broke them everywhere else. Pinning the zone in `jest.config.ts` makes them reproducible instead:

```ts
process.env.TZ = "Asia/Kolkata";
```

Set in `jest.config.ts` rather than `setupFiles` because the config is evaluated in the parent process before workers fork, so they inherit it at startup — once Node has cached the zone it is too late to change it.

## How Has This Been Tested?

- [x] Locally

Suite goes from 2 failed / 2 passed to **4 passed**, and I verified it is genuinely timezone-agnostic rather than just green here:

| `TZ` | result |
|---|---|
| `Europe/London` | 4 passed |
| `America/New_York` | 4 passed |
| `Asia/Kolkata` | 4 passed |
| `Pacific/Auckland` | 4 passed |
| `UTC` | 4 passed |

`tsc --noEmit` and `prettier --check` clean.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings

## Notes for reviewers

- **No test covers a missing/null forecast `PowerKW`.** The existing "with missing data" case is about missing *generation*, so the behaviour this PR changes is uncovered either way. Worth adding a case — happy to, either here or as a follow-up.
- `convertDatestampToEpoch` stripping the offset is a latent production bug, not just a test one. It is left alone here because the strip-then-format-local round trip is currently load-bearing for how IST times are displayed, and unpicking it deserves its own PR.
