### PR TITLE
✨ Quartz Solar v0.7.5 → Staging

### DIFF
--- a/apps/nowcasting-app/components/hooks/statusOrdering.test.ts
+++ b/apps/nowcasting-app/components/hooks/statusOrdering.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "@jest/globals";
+import { orderStatuses } from "./useStatus";
+import { ProductStatus, StatusLevel } from "../types";
+
+const status = (
+  key: string,
+  level: StatusLevel,
+  message: string | null = "something happened",
+  updatedAt: string | null = "2026-08-18T10:00:00.000Z"
+): ProductStatus => ({
+  key,
+  name: key,
+  status: level,
+  message,
+  source: "manual",
+  updatedAt
+});
+
+describe("orderStatuses", () => {
+  test("drops ok, whatever it says", () => {
+    // The Status API always sends a message — every product reads "Operating within normal
+    // parameters." today — so an ok row must be dropped on its level, not its text.
+    // Without this the app carries a permanent banner.
+    expect(
+      orderStatuses([status("gb-solar", "ok", "Operating within normal parameters.")])
+    ).toEqual([]);
+  });
+
+  test("drops a row with no message to show", () => {
+    expect(orderStatuses([status("gb-solar", "error", "   ")])).toEqual([]);
+    // `message` is nullable in the spec — a product can carry a status with nothing to say.
+    expect(orderStatuses([status("gb-solar", "error", null)])).toEqual([]);
+  });
+
+  test("sorts worst first, matching the order the API rolls up with", () => {
+    // The API's own severity order is ok < info < unknown < warning < error (spec v0.2.0);
+    // this is that, reversed. A UI that disagreed would sort a product above the very
+    // rollup value the API derived from it.
+    const ordered = orderStatuses([
+      status("gb-solar", "info"),
+      status("nl-solar", "error"),
+      status("asset-solar", "warning"),
+      status("unregistered", "unknown")
+    ]);
+    expect(ordered.map((s) => s.status)).toEqual(["error", "warning", "unknown", "info"]);
+  });
+
+  test("breaks ties on the configured product order, not payload order", () => {
+    const ordered = orderStatuses([
+      status("asset-solar", "warning"),
+      status("nl-solar", "warning"),
+      status("gb-solar", "warning")
+    ]);
+    expect(ordered.map((s) => s.key)).toEqual(["gb-solar", "nl-solar", "asset-solar"]);
+  });
+
+  test("keeps unknown visible, ranked below warning", () => {
+    const ordered = orderStatuses([status("gb-solar", "unknown"), status("nl-solar", "warning")]);
+    expect(ordered.map((s) => s.status)).toEqual(["warning", "unknown"]);
+  });
+});

--- a/apps/nowcasting-app/components/hooks/useDismissedStatuses.test.ts
+++ b/apps/nowcasting-app/components/hooks/useDismissedStatuses.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "@jest/globals";
+import { statusDismissalId } from "./useDismissedStatuses";
+import { ProductStatus } from "../types";
+
+const incident = (updatedAt: string | null, message: string): ProductStatus => ({
+  key: "gb-solar",
+  name: "GB Solar",
+  status: "error",
+  message,
+  source: "manual",
+  updatedAt
+});
+
+describe("statusDismissalId", () => {
+  test("is stable across re-polls of the same incident", () => {
+    const a = incident("2026-08-18T10:00:00.000Z", "Forecast delayed");
+    const b = incident("2026-08-18T10:00:00.000Z", "Forecast delayed");
+    expect(statusDismissalId(a)).toBe(statusDismissalId(b));
+  });
+
+  test("changes when the incident is updated, so a dismissed row returns", () => {
+    // This is the whole reason the id is `key:updatedAt` rather than just `key`: dismissing
+    // means "I have read this", not "hide this product forever".
+    const before = incident("2026-08-18T10:00:00.000Z", "Forecast delayed");
+    const after = incident("2026-08-18T11:30:00.000Z", "Forecast delayed by 2 hours");
+    expect(statusDismissalId(before)).not.toBe(statusDismissalId(after));
+  });
+
+  test("still separates incidents when updatedAt is null", () => {
+    // `updatedAt` is nullable in the spec. Keying on it raw would give every unstamped
+    // incident on a product the same id, so dismissing one would swallow the next.
+    const before = incident(null, "Forecast delayed");
+    const after = incident(null, "Forecast delayed by 2 hours");
+    expect(statusDismissalId(before)).not.toBe(statusDismissalId(after));
+    expect(statusDismissalId(before)).toBe(statusDismissalId(incident(null, "Forecast delayed")));
+  });
+
+  test("is scoped per product", () => {
+    const gb = incident("2026-08-18T10:00:00.000Z", "Forecast delayed");
+    const nl = { ...gb, key: "nl-solar" };
+    expect(statusDismissalId(gb)).not.toBe(statusDismissalId(nl));
+  });
+});

--- a/apps/nowcasting-app/components/hooks/useDismissedStatuses.ts
+++ b/apps/nowcasting-app/components/hooks/useDismissedStatuses.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useState } from "react";
+import { ProductStatus } from "../types";
+
+/**
+ * Per-session dismissal of status banner rows.
+ *
+ * The identity of a dismissal is `${key}:${updatedAt}`, taken straight from the payload.
+ * That is what makes "dismiss" mean "I have read *this* incident" rather than "hide this
+ * product": when the status changes — a new incident, or an edit to the message — `updatedAt`
+ * moves and the row comes back on its own. No hashing, no expiry, nothing to keep in sync
+ * with the message text.
+ *
+ * `updatedAt` is nullable in the spec, so it cannot be used raw. Falling back to `key` alone
+ * would give every incident on an unstamped product the same id, and dismissing one would
+ * silently swallow the next — so the message stands in as the identity instead, which moves
+ * when the incident does.
+ *
+ * `sessionStorage` rather than `localStorage` is deliberate: an incident dismissed on Monday
+ * should not still be hidden on Friday if it is somehow still open.
+ */
+
+const STORAGE_KEY = "quartz.dismissedStatuses";
+
+export const statusDismissalId = (status: ProductStatus): string =>
+  `${status.key}:${status.updatedAt ?? status.message ?? ""}`;
+
+const readStored = (): string[] => {
+  // Guarded for SSR, and for browsers where storage access throws (private mode, blocked
+  // cookies). A failure here must degrade to "nothing dismissed", never to a crashed banner.
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed.filter((id) => typeof id === "string") : [];
+  } catch {
+    return [];
+  }
+};
+
+const writeStored = (ids: string[]) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  } catch {
+    // Dismissal not persisting is a far smaller problem than the banner failing to render.
+  }
+};
+
+export const useDismissedStatuses = () => {
+  // Starts empty on both server and first client render, then fills from storage in an
+  // effect. Reading storage during render would desync the two and trip hydration.
+  const [dismissedIds, setDismissedIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    setDismissedIds(readStored());
+  }, []);
+
+  const dismiss = useCallback((status: ProductStatus) => {
+    const id = statusDismissalId(status);
+    setDismissedIds((current) => {
+      if (current.includes(id)) return current;
+      const next = [...current, id];
+      writeStored(next);
+      return next;
+    });
+  }, []);
+
+  const isDismissed = useCallback(
+    (status: ProductStatus) => dismissedIds.includes(statusDismissalId(status)),
+    [dismissedIds]
+  );
+
+  return { isDismissed, dismiss };
+};

--- a/apps/nowcasting-app/components/hooks/useLoadDataFromApi.tsx
+++ b/apps/nowcasting-app/components/hooks/useLoadDataFromApi.tsx
@@ -8,8 +8,7 @@ import {
   NationalNHourData,
   PvRealData,
   SitesPvActual,
-  SitesPvForecast,
-  SolarStatus
+  SitesPvForecast
 } from "../types";
 import useSWR, { SWRConfiguration, SWRResponse } from "swr";
 import { axiosFetcherAuth, openapiFetcherAuth } from "../helpers/utils";
@@ -31,7 +30,6 @@ type APIResponseType =
   | AllSites
   | SitesPvForecast
   | SitesPvActual
-  | SolarStatus
   | FcAllResData
   | ResponseObjectMap<operations>;
 export const useLoadDataFromApi = <T extends APIResponseType>(

--- a/apps/nowcasting-app/components/hooks/useStatus.test.ts
+++ b/apps/nowcasting-app/components/hooks/useStatus.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "@jest/globals";
+import { normaliseLevel } from "./useStatus";
+
+describe("normaliseLevel", () => {
+  test("passes through every level the API spec publishes", () => {
+    // ProductStatusValue, spec v0.2.0.
+    expect(normaliseLevel("ok")).toBe("ok");
+    expect(normaliseLevel("info")).toBe("info");
+    expect(normaliseLevel("warning")).toBe("warning");
+    expect(normaliseLevel("error")).toBe("error");
+    expect(normaliseLevel("unknown")).toBe("unknown");
+  });
+
+  test("tolerates casing and whitespace", () => {
+    expect(normaliseLevel(" Warning ")).toBe("warning");
+    expect(normaliseLevel("ERROR")).toBe("error");
+  });
+
+  test("falls back to unknown, not info, for a level it cannot read", () => {
+    // Failing towards visible is deliberate — silently swallowing a level we do not know
+    // would hide a real incident. `unknown` rather than `info` because `info` now means a
+    // deliberate non-degraded notice, and it ranks lower, so it would fail quiet.
+    expect(normaliseLevel("degraded")).toBe("unknown");
+    expect(normaliseLevel("")).toBe("unknown");
+    expect(normaliseLevel(undefined)).toBe("unknown");
+    expect(normaliseLevel(null)).toBe("unknown");
+    expect(normaliseLevel(3)).toBe("unknown");
+  });
+});

--- a/apps/nowcasting-app/components/hooks/useStatus.test.ts
+++ b/apps/nowcasting-app/components/hooks/useStatus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "@jest/globals";
-import { normaliseLevel } from "./useStatus";
+import { normaliseLevel, normaliseMessage } from "./useStatus";
 
 describe("normaliseLevel", () => {
   test("passes through every level the API spec publishes", () => {
@@ -25,5 +25,23 @@ describe("normaliseLevel", () => {
     expect(normaliseLevel(undefined)).toBe("unknown");
     expect(normaliseLevel(null)).toBe("unknown");
     expect(normaliseLevel(3)).toBe("unknown");
+  });
+});
+
+describe("normaliseMessage", () => {
+  test("trims a string message", () => {
+    expect(normaliseMessage("  Forecast delayed  ")).toBe("Forecast delayed");
+    expect(normaliseMessage("")).toBe("");
+  });
+
+  test("returns empty string for anything that is not a string", () => {
+    // The point is that none of these throw. `.trim()` on a non-string would take down the
+    // whole render, since this runs in a hook body — one malformed field would blank the app
+    // rather than drop one banner row. An empty message means the row is not drawn.
+    expect(normaliseMessage(null)).toBe("");
+    expect(normaliseMessage(undefined)).toBe("");
+    expect(normaliseMessage(42)).toBe("");
+    expect(normaliseMessage({ text: "nope" })).toBe("");
+    expect(normaliseMessage(["nope"])).toBe("");
   });
 });

--- a/apps/nowcasting-app/components/hooks/useStatus.ts
+++ b/apps/nowcasting-app/components/hooks/useStatus.ts
@@ -2,6 +2,7 @@ import useSWR from "swr";
 import { ProductStatus, ProductsResponse, StatusLevel } from "../types";
 import { axiosFetcher } from "../helpers/utils";
 import {
+  KNOWN_LEVELS,
   entitledStatusProducts,
   isKnownProduct,
   productOrder,
@@ -32,8 +33,6 @@ const STATUS_URL = process.env.NEXT_PUBLIC_STATUS_URL;
  */
 const STATUS_REFRESH_INTERVAL_MS = 60_000;
 
-const KNOWN_LEVELS: StatusLevel[] = ["ok", "info", "warning", "error", "unknown"];
-
 /**
  * Anything the API sends that we do not recognise becomes `unknown`.
  *
@@ -49,10 +48,21 @@ export const normaliseLevel = (level: unknown): StatusLevel => {
   return (KNOWN_LEVELS as string[]).includes(trimmed) ? (trimmed as StatusLevel) : "unknown";
 };
 
+/**
+ * Anything that is not a string becomes `""` — same reasoning as `normaliseLevel` above.
+ *
+ * `ProductStatus.message` is typed `string | null`, but that is an assertion about an HTTP
+ * response, not a guarantee about one. A number or an object arriving here would make
+ * `.trim()` throw, and this runs in a hook body, so the throw takes the whole render down —
+ * a malformed field on one product would blank the app rather than drop one banner row.
+ */
+export const normaliseMessage = (message: unknown): string =>
+  typeof message === "string" ? message.trim() : "";
+
 const normaliseProduct = (product: ProductStatus): ProductStatus => ({
   ...product,
   status: normaliseLevel(product.status),
-  message: product.message?.trim() ?? ""
+  message: normaliseMessage(product.message)
 });
 
 /**

--- a/apps/nowcasting-app/components/hooks/useStatus.ts
+++ b/apps/nowcasting-app/components/hooks/useStatus.ts
@@ -1,0 +1,117 @@
+import useSWR from "swr";
+import { ProductStatus, ProductsResponse, StatusLevel } from "../types";
+import { axiosFetcher } from "../helpers/utils";
+import {
+  entitledStatusProducts,
+  isKnownProduct,
+  productOrder,
+  severityRank
+} from "../../config/statusProducts";
+
+/**
+ * The status banner's one and only backend.
+ *
+ * Previously the banner read status off the *data* APIs — `${API_PREFIX}/solar/GB/status`
+ * and `${SITES_API_PREFIX}/api_status` — which meant "is the service up" was answered by the
+ * same service being asked about, and only ever for GB. Both are now replaced by the Status
+ * API's product model at `NEXT_PUBLIC_STATUS_URL`.
+ *
+ * `GET /products` returns every product in one call, so there is exactly one request here
+ * however many products exist. It is unauthenticated and sends `access-control-allow-origin: *`,
+ * hence the plain `axiosFetcher` rather than `axiosFetcherAuth`/`useLoadDataFromApi` — the
+ * latter would attach a bearer token this API does not want and append the `UI=true` flag
+ * that only the data APIs understand.
+ */
+
+const STATUS_URL = process.env.NEXT_PUBLIC_STATUS_URL;
+
+/**
+ * Faster than the app's 5-minute data default: an incident is worth knowing about promptly.
+ * No point going below the API's own `Cache-Control: public, max-age=15` — a tighter poll
+ * would only re-read the same cached body.
+ */
+const STATUS_REFRESH_INTERVAL_MS = 60_000;
+
+const KNOWN_LEVELS: StatusLevel[] = ["ok", "info", "warning", "error", "unknown"];
+
+/**
+ * Anything the API sends that we do not recognise becomes `unknown`.
+ *
+ * Not `info`: since spec v0.2.0 `info` has a meaning of its own — a deliberate, non-degraded
+ * notice — so labelling an unrecognised value `info` would claim we had understood it.
+ * `unknown` is the honest answer, and it ranks above `info` in severity, so a level we
+ * cannot read fails loud rather than quiet. Either way the row still renders: silently
+ * swallowing a level we do not know would hide a real incident.
+ */
+export const normaliseLevel = (level: unknown): StatusLevel => {
+  if (typeof level !== "string") return "unknown";
+  const trimmed = level.trim().toLowerCase();
+  return (KNOWN_LEVELS as string[]).includes(trimmed) ? (trimmed as StatusLevel) : "unknown";
+};
+
+const normaliseProduct = (product: ProductStatus): ProductStatus => ({
+  ...product,
+  status: normaliseLevel(product.status),
+  message: product.message?.trim() ?? ""
+});
+
+/**
+ * Every product status this user is entitled to see, normalised. `ok` rows are included —
+ * filtering them out is the banner's call, not the transport's.
+ *
+ * Returns `[]` when `NEXT_PUBLIC_STATUS_URL` is unset (the SWR key goes `null`, so nothing
+ * is fetched) — the banner then renders nothing rather than the app erroring.
+ */
+export const useProductStatuses = (): ProductStatus[] => {
+  const { data } = useSWR<ProductsResponse, Error>(
+    STATUS_URL ? `${STATUS_URL}/products` : null,
+    axiosFetcher,
+    {
+      refreshInterval: STATUS_REFRESH_INTERVAL_MS,
+      keepPreviousData: true,
+      // A status service that is itself down should not spam Sentry or the network log.
+      //
+      // This also means a 503 "status store unavailable" — the API staying up and answering
+      // honestly that its database is down — shows as silence, indistinguishable from
+      // all-clear. Deliberately left as-is for now: a full-width banner is too shouty for "we
+      // cannot currently tell you". It gets proper handling with the Europe UI, which needs a
+      // subtler way to show per-product status anyway.
+      shouldRetryOnError: false
+    }
+  );
+
+  const products = data?.products;
+  if (!Array.isArray(products)) return [];
+
+  // The entitlement filter has exactly one home. Today it lets every *registered* product
+  // through; when the Europe UI locks it down to the token's `products` claim, this is the
+  // only caller that has to change.
+  //
+  // A product the API serves but config/statusProducts.ts does not know about is dropped
+  // rather than shown. That is the right way round once entitlement is real — we should
+  // never render a status we cannot attribute an entitlement to — and the cost is that a
+  // newly launched product needs one line of config before its banner appears.
+  const entitled = entitledStatusProducts() as string[];
+  return products
+    .filter((product) => isKnownProduct(product.key) && entitled.includes(product.key))
+    .map(normaliseProduct);
+};
+
+/**
+ * The rows the banner should actually draw, worst first.
+ *
+ * `ok` never renders. The Status API always sends a message — every product currently reads
+ * "Operating within normal parameters." — so keying off "is there a message" would pin a
+ * permanent banner to the top of the app. The level is what decides, not the text.
+ *
+ * Lives here rather than in the component so it is a plain function the suite can call
+ * directly: there is no jsdom in this project, so anything reachable only through a render
+ * is untestable.
+ */
+export const orderStatuses = (statuses: ProductStatus[]): ProductStatus[] =>
+  statuses
+    .filter((status) => status.status !== "ok" && (status.message ?? "").trim() !== "")
+    .sort(
+      (a, b) =>
+        severityRank(a.status) - severityRank(b.status) || productOrder(a.key) - productOrder(b.key)
+    );

--- a/apps/nowcasting-app/components/layout/StatusBanner.tsx
+++ b/apps/nowcasting-app/components/layout/StatusBanner.tsx
@@ -16,13 +16,27 @@ const StatusBanner = ({ view, solarStatus, sitesStatus }: StatusBannerProps) => 
     status = solarStatus;
   }
 
-  if (!status || status.status === "ok" || status.message === "") {
+  const message = status?.message?.trim();
+
+  if (!message) {
     return null;
+  }
+
+  let emoji = "ℹ️";
+  switch (status?.status?.trim().toLowerCase()) {
+    case "warning":
+      emoji = "⚠️";
+      break;
+    case "error":
+      emoji = "🚨";
+      break;
   }
 
   return (
     <div className="bg-mapbox-black text-ocf-gray-600 text-center px-4 py-2">
-      <p>⚠️&nbsp;{solarStatus?.message}</p>
+      <p>
+        {emoji}&nbsp;{message}
+      </p>
     </div>
   );
 };

--- a/apps/nowcasting-app/components/layout/StatusBanner.tsx
+++ b/apps/nowcasting-app/components/layout/StatusBanner.tsx
@@ -1,42 +1,76 @@
-import { VIEWS } from "../../constant";
-import { SolarStatus } from "../types";
+import { ProductStatus, StatusLevel } from "../types";
+import { productLabel } from "../../config/statusProducts";
+import { orderStatuses } from "../hooks/useStatus";
+import { statusDismissalId, useDismissedStatuses } from "../hooks/useDismissedStatuses";
+import { CrossInlineSmall } from "../icons/icons";
 
 interface StatusBannerProps {
-  view: VIEWS;
-  solarStatus?: SolarStatus;
-  sitesStatus?: SolarStatus;
+  statuses: ProductStatus[];
 }
 
-const StatusBanner = ({ view, solarStatus, sitesStatus }: StatusBannerProps) => {
-  let status;
+/**
+ * Per-level presentation. Full class strings, not interpolated fragments, so Tailwind's
+ * scanner actually sees them.
+ *
+ * The rows share one dark background and are separated by a coloured left edge rather than
+ * by a coloured fill: with several stacked at the top of a dark dashboard, full-bleed
+ * severity colours read as an alert wall and swamp the chart below.
+ */
+const LEVEL_STYLES: Record<Exclude<StatusLevel, "ok">, { emoji: string; accent: string }> = {
+  error: { emoji: "🚨", accent: "border-red-500" },
+  warning: { emoji: "⚠️", accent: "border-ocf-yellow-500" },
+  // A check that cannot report on itself is worth surfacing, quietly — a grey edge says
+  // "we don't know" without claiming something is broken.
+  unknown: { emoji: "❓", accent: "border-mapbox-black-400" },
+  // A deliberate notice with nothing degraded — planned maintenance, a heads-up. Blue and
+  // informational on purpose: reusing the warning yellow would cry wolf.
+  info: { emoji: "ℹ️", accent: "border-ocf-blue-500" }
+};
 
-  if (view === VIEWS.SOLAR_SITES) {
-    status = sitesStatus;
-  } else {
-    status = solarStatus;
-  }
+const StatusBanner = ({ statuses }: StatusBannerProps) => {
+  const { isDismissed, dismiss } = useDismissedStatuses();
 
-  const message = status?.message?.trim();
+  const ordered = orderStatuses(statuses);
+  const visible = ordered.filter((status) => !isDismissed(status));
 
-  if (!message) {
+  if (!visible.length) {
     return null;
   }
 
-  let emoji = "ℹ️";
-  switch (status?.status?.trim().toLowerCase()) {
-    case "warning":
-      emoji = "⚠️";
-      break;
-    case "error":
-      emoji = "🚨";
-      break;
-  }
-
   return (
-    <div className="bg-mapbox-black text-ocf-gray-600 text-center px-4 py-2">
-      <p>
-        {emoji}&nbsp;{message}
-      </p>
+    <div className="flex flex-col">
+      {visible.map((status) => {
+        const { emoji, accent } = LEVEL_STYLES[status.status as Exclude<StatusLevel, "ok">];
+
+        return (
+          <div
+            key={statusDismissalId(status)}
+            className={`flex items-center gap-3 border-l-4 bg-mapbox-black px-4 py-2 text-ocf-gray-600 ${accent}`}
+          >
+            {/* Left-aligned, not centred like the old single banner: the severity colour is
+                carried by the left edge, and a message centred half a screen away from it does
+                not read as belonging to it. */}
+            <p className="flex-1">
+              {emoji}&nbsp;
+              {/* Always named, even when it is the only row. The message text alone cannot be
+                  trusted to say which product it is about — "issues with the forecast" reads as
+                  *your* forecast — so an unlabelled row can misattribute another country's
+                  incident. Labelling unconditionally also avoids reintroducing a dependency on
+                  the current view, which is what the old banner switched on. */}
+              <span className="font-semibold">{productLabel(status.key, status.name)}: </span>
+              {status.message}
+            </p>
+            <button
+              type="button"
+              onClick={() => dismiss(status)}
+              className="shrink-0 p-1 text-ocf-gray-800 hover:text-ocf-gray-600"
+              aria-label={`Dismiss ${productLabel(status.key, status.name)} status message`}
+            >
+              <CrossInlineSmall title="Dismiss" />
+            </button>
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/apps/nowcasting-app/components/layout/layout.tsx
+++ b/apps/nowcasting-app/components/layout/layout.tsx
@@ -1,8 +1,7 @@
 import Head from "next/head";
 import { Analytics } from "@vercel/analytics/next";
-import { API_PREFIX, SITES_API_PREFIX, getViewTitle, VIEWS } from "../../constant";
-import { useLoadDataFromApi } from "../hooks/useLoadDataFromApi";
-import { SolarStatus } from "../types";
+import { getViewTitle } from "../../constant";
+import { useProductStatuses } from "../hooks/useStatus";
 import useGlobalState from "../helpers/globalState";
 import StatusBanner from "./StatusBanner";
 
@@ -12,8 +11,11 @@ interface ILayout {
 }
 
 const Layout = ({ children }: ILayout) => {
-  const { data: solarStatus } = useLoadDataFromApi<SolarStatus>(`${API_PREFIX}/solar/GB/status`);
-  const { data: sitesStatus } = useLoadDataFromApi<SolarStatus>(`${SITES_API_PREFIX}/api_status`);
+  // Every product the user is entitled to, in one call. The banner is no longer scoped to
+  // the current view: an outage on a product the user is not looking at is still worth
+  // knowing about, and dropping the view dependency keeps this file out of the way of the
+  // Europe UI work, which replaces `view` with `isSitesChart` + `comparison`.
+  const statuses = useProductStatuses();
   const [view] = useGlobalState("view");
   const viewTitle = getViewTitle(view);
   const pageTitle = view && viewTitle ? `Quartz Solar - ${viewTitle}` : "Quartz Solar";
@@ -25,7 +27,7 @@ const Layout = ({ children }: ILayout) => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <main className="flex flex-col h-screen">
-        <StatusBanner view={view} solarStatus={solarStatus} sitesStatus={sitesStatus} />
+        <StatusBanner statuses={statuses} />
         {children}
         <Analytics />
       </main>

--- a/apps/nowcasting-app/components/types.d.ts
+++ b/apps/nowcasting-app/components/types.d.ts
@@ -207,9 +207,42 @@ type GspDeltaValue = {
   deltaNormalized: string;
 };
 
-export type SolarStatus = {
-  status: string;
-  message: string;
+/**
+ * One product's status from the Status API (`GET /products`), spec v0.2.0.
+ *
+ * `ProductStatusValue` is `ok | info | warning | error | unknown`. `info` means a
+ * deliberate, non-degraded notice — planned maintenance, a heads-up — and is distinct from
+ * `unknown`, which means no signal at all. See `normaliseLevel` in
+ * components/hooks/useStatus.ts for how an unrecognised level is handled.
+ */
+export type StatusLevel = "ok" | "info" | "warning" | "error" | "unknown";
+
+export type ProductStatus = {
+  /** Product key, e.g. `"gb-solar"`. Permanent identifier. See config/statusProducts.ts. */
+  key: string;
+  /** The API's own display name, used as the label fallback for an unregistered product. */
+  name: string;
+  status: StatusLevel;
+  /** Nullable per the spec — a product can carry a status with nothing to say about it. */
+  message: string | null;
+  /** How the status was set, e.g. `"manual"`. */
+  source: string;
+  /**
+   * ISO-8601, nullable. Doubles as the incident identity for dismissal, which is why
+   * useDismissedStatuses needs a fallback for the null case rather than keying on it raw.
+   *
+   * Not to be confused with history's `setAt`: a status row is updated in place, whereas a
+   * history row records a status being set. The two names differ deliberately.
+   */
+  updatedAt: string | null;
+};
+
+export type ProductsResponse = {
+  /** Worst-of rollup across products. Unused today — each row is rendered on its own level. */
+  status: StatusLevel;
+  products: ProductStatus[];
+  /** Most recent `updatedAt` across products, or null when none has ever been stamped. */
+  lastUpdated: string | null;
 };
 
 export type Bucket = {

--- a/apps/nowcasting-app/config/statusProducts.test.ts
+++ b/apps/nowcasting-app/config/statusProducts.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  PRODUCTS_CLAIM_KEY,
+  PRODUCTS_CLAIM_KEY_NAMESPACED,
+  readProductsClaim
+} from "./statusProducts";
+
+describe("readProductsClaim", () => {
+  test("reads the bare spelling that is set on the dev tenant", () => {
+    expect(readProductsClaim({ [PRODUCTS_CLAIM_KEY]: ["gb-solar", "nl-solar"] })).toEqual([
+      "gb-solar",
+      "nl-solar"
+    ]);
+  });
+
+  test("reads the namespaced spelling too", () => {
+    // The whole point of the dual read: Auth0 silently drops non-namespaced custom claims
+    // added by an Action, so the bare spelling may not survive and we cannot tell from here.
+    expect(readProductsClaim({ [PRODUCTS_CLAIM_KEY_NAMESPACED]: ["asset-solar"] })).toEqual([
+      "asset-solar"
+    ]);
+  });
+
+  test("prefers the bare spelling when a token somehow carries both", () => {
+    expect(
+      readProductsClaim({
+        [PRODUCTS_CLAIM_KEY]: ["gb-solar"],
+        [PRODUCTS_CLAIM_KEY_NAMESPACED]: ["nl-solar"]
+      })
+    ).toEqual(["gb-solar"]);
+  });
+
+  test("normalises casing and whitespace, and drops empties", () => {
+    expect(readProductsClaim({ products: [" GB-Solar ", "", "   "] })).toEqual(["gb-solar"]);
+  });
+
+  test("de-duplicates, since downstream this is a membership set", () => {
+    expect(readProductsClaim({ products: ["gb-solar", "GB-SOLAR"] })).toEqual(["gb-solar"]);
+  });
+
+  test("degrades to nothing entitled rather than throwing", () => {
+    // A missing or malformed claim must never crash a session. It fails closed, which is why
+    // the switch-over needs a real token decoded first — this is silent by design.
+    expect(readProductsClaim(null)).toEqual([]);
+    expect(readProductsClaim(undefined)).toEqual([]);
+    expect(readProductsClaim("gb-solar")).toEqual([]);
+    expect(readProductsClaim({})).toEqual([]);
+    expect(readProductsClaim({ products: "gb-solar" })).toEqual([]);
+    expect(readProductsClaim({ products: [1, null, {}] })).toEqual([]);
+  });
+
+  test("leaves unregistered keys in — intersecting is the caller's job", () => {
+    expect(readProductsClaim({ products: ["de-solar"] })).toEqual(["de-solar"]);
+  });
+});

--- a/apps/nowcasting-app/config/statusProducts.ts
+++ b/apps/nowcasting-app/config/statusProducts.ts
@@ -1,0 +1,132 @@
+import { StatusLevel } from "../components/types";
+
+/**
+ * The Status API's product registry.
+ *
+ * The status service models everything as a "product" — `gb-solar`, `nl-solar`,
+ * `asset-solar` (formerly "sites") — deliberately agnostic about whether a product is a
+ * country, a data source, or a whole separate app. This file is the only place that knows
+ * those keys, so the app never spells a product string inline.
+ *
+ * Declared data, no branching. Adding a product is one entry here.
+ *
+ * When the Europe UI lands, the country -> product link belongs on `CountryConfig` as a
+ * `statusProduct` field rather than here, so `enabledCountries` can drive which rows show.
+ * Until then nothing filters by country or view: every product's status is shown to
+ * everyone (see `entitledStatusProducts`).
+ */
+
+export type StatusProductKey = "gb-solar" | "nl-solar" | "asset-solar";
+
+type StatusProductConfig = {
+  /** Shown as the row's label when more than one product is reporting at once. */
+  label: string;
+  /** Tie-break ordering within a severity band. Lower sorts first. */
+  order: number;
+};
+
+export const STATUS_PRODUCTS: Record<StatusProductKey, StatusProductConfig> = {
+  "gb-solar": { label: "GB Solar", order: 0 },
+  "nl-solar": { label: "NL Solar", order: 1 },
+  // The status API's name for what this app still calls "sites" throughout. The rename
+  // lives here at the boundary and nowhere else.
+  "asset-solar": { label: "Asset Solar", order: 2 }
+};
+
+export const isKnownProduct = (key: string): key is StatusProductKey =>
+  Object.prototype.hasOwnProperty.call(STATUS_PRODUCTS, key);
+
+/**
+ * Bare spelling, no namespace — what is actually set on the Auth0 dev tenant, following the
+ * `trial_ends_at` precedent read straight off `session.user` in pages/api/get_token.ts.
+ */
+export const PRODUCTS_CLAIM_KEY = "products";
+
+/**
+ * Namespaced spelling, per Auth0's custom-claim convention.
+ *
+ * Both are read because the bare one may not survive. Auth0 silently drops non-namespaced
+ * custom claims that an Action adds to a token; `trial_ends_at` works un-namespaced in
+ * production, but most likely arrives by another route (a root profile attribute rather than
+ * an Action-set claim), so it is not proof that `products` will. Reading both costs a line
+ * and removes the question. lib/api/auth/entitlement.ts does the same for `countries`.
+ *
+ * Delete whichever spelling turns out to be unused once the Action ships.
+ */
+export const PRODUCTS_CLAIM_KEY_NAMESPACED = "https://quartz.solar/products";
+
+/**
+ * Pulls the product claim off an Auth0 user/session object.
+ *
+ * `user` is `unknown` on purpose: it arrives from `useUser()`, from `getSession()`, or from
+ * the JSON `/api/get_token` returns, and at least one of those can be null mid-session.
+ * Anything that is not an array of non-empty strings is treated as absent, so a missing or
+ * malformed claim degrades to "nothing entitled" and never throws.
+ *
+ * Keys are lower-cased to match how the status API spells them, so a claim written
+ * `["GB-Solar"]` still matches. Unknown keys are left in — intersecting against the registry
+ * is the caller's job.
+ */
+export const readProductsClaim = (user: unknown): string[] => {
+  if (user === null || typeof user !== "object") return [];
+
+  const record = user as Record<string, unknown>;
+  const raw = record[PRODUCTS_CLAIM_KEY] ?? record[PRODUCTS_CLAIM_KEY_NAMESPACED];
+  if (!Array.isArray(raw)) return [];
+
+  const keys = raw
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0);
+
+  // A malformed claim can repeat a key; downstream this is a membership set, not a list.
+  return Array.from(new Set(keys));
+};
+
+/**
+ * Which products this user is allowed to see the status of.
+ *
+ * Returns all of them today, deliberately — we would rather show a GB-only customer an NL
+ * incident than hide a GB one through a half-built entitlement check. `readProductsClaim`
+ * above is the mechanism, built and tested but not yet wired in: the lock-down ships with
+ * the Europe UI, and this is the one function that changes when it does. `useProductStatuses`
+ * is the single place entitlement is applied.
+ *
+ * It reads a **`products`** claim, not the `countries` claim the Europe UI epic currently
+ * builds against. That is a settled decision, not a preference: `asset-solar` is not a
+ * country, so no arrangement of country roles can ever entitle it. The epic will be amended
+ * to match, and the claim is already on the Auth0 dev tenant.
+ *
+ * Before switching this over, decode a real dev token and confirm the claim actually
+ * survives — a dropped claim fails silently, and once this stops returning everything it
+ * degrades to "nothing entitled" for every user at once. Note also that dev mode serves a
+ * literal `FAKE_TOKEN` with no claims (pages/api/get_token.ts), so this will need the same
+ * explicit bypass the epic's entitlement module has, or local development renders no
+ * statuses at all.
+ */
+export const entitledStatusProducts = (): StatusProductKey[] =>
+  Object.keys(STATUS_PRODUCTS) as StatusProductKey[];
+
+/**
+ * Worst first. `ok` never reaches the banner, but is ordered here for completeness.
+ *
+ * This is the exact reverse of the severity order the Status API uses for its own worst-of
+ * rollup (`ok < info < unknown < warning < error`, spec v0.2.0). Keep it that way — a UI that
+ * ranked these differently from the API would sort a product above the very rollup value it
+ * produced.
+ */
+const SEVERITY_ORDER: Record<StatusLevel, number> = {
+  error: 0,
+  warning: 1,
+  unknown: 2,
+  info: 3,
+  ok: 4
+};
+
+export const severityRank = (level: StatusLevel): number => SEVERITY_ORDER[level];
+
+export const productOrder = (key: string): number =>
+  isKnownProduct(key) ? STATUS_PRODUCTS[key].order : Number.MAX_SAFE_INTEGER;
+
+export const productLabel = (key: string, fallback: string): string =>
+  isKnownProduct(key) ? STATUS_PRODUCTS[key].label : fallback;

--- a/apps/nowcasting-app/config/statusProducts.ts
+++ b/apps/nowcasting-app/config/statusProducts.ts
@@ -125,8 +125,24 @@ const SEVERITY_ORDER: Record<StatusLevel, number> = {
 
 export const severityRank = (level: StatusLevel): number => SEVERITY_ORDER[level];
 
+/**
+ * The runtime list of levels, derived rather than spelled out a second time.
+ *
+ * `StatusLevel` is a type, so there is nothing in types.d.ts to read at runtime. But
+ * `SEVERITY_ORDER` above is typed `Record<StatusLevel, number>`, which the compiler already
+ * refuses to let you leave incomplete — so its keys are a list that cannot go stale. A
+ * hand-maintained array could: add a level to `StatusLevel`, forget the array, and every
+ * product on the new level normalises to `unknown` with nothing failing to warn you.
+ */
+export const KNOWN_LEVELS = Object.keys(SEVERITY_ORDER) as StatusLevel[];
+
 export const productOrder = (key: string): number =>
   isKnownProduct(key) ? STATUS_PRODUCTS[key].order : Number.MAX_SAFE_INTEGER;
 
+/**
+ * `fallback` is defence in depth, not a live path: `useProductStatuses` drops products the
+ * registry does not know, so every key reaching the banner is registered and the fallback
+ * never fires today. It stays so a future caller that does not filter still renders a name.
+ */
 export const productLabel = (key: string, fallback: string): string =>
   isKnownProduct(key) ? STATUS_PRODUCTS[key].label : fallback;

--- a/apps/nowcasting-app/package.json
+++ b/apps/nowcasting-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclimatefix/nowcasting-app",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",

--- a/apps/nowcasting-app/sentry.client.config.js
+++ b/apps/nowcasting-app/sentry.client.config.js
@@ -39,6 +39,17 @@ Sentry.init({
   // sessions when an error occurs.
   replaysOnErrorSampleRate: 1.0,
 
+  // TMP remove it after v1 merge
+  // suppress known noisy/expected errors
+  ignoreErrors: [
+    /Failed to get access token/,
+    /Failed to get auth token/,
+    /Hydration failed/,
+    /Failed to fetch/,
+    /NetworkError when attempting to fetch resource/,
+    /The operation was aborted/
+  ],
+
   integrations: (integrations) => {
     return [
       ...integrations,

--- a/docs/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/docs/PULL_REQUEST_TEMPLATE/release_template.md
@@ -68,6 +68,20 @@
 - [ ] If I select a DNO, does the aggregated chart show for that DNO?
 - [ ] If I have a DNO selected, and click the "GSP" map button, does it deselect the DNO?
 - [ ] If I have a GSP selected, and click the "DNO" map button, does it deselect the GSP?
+- [ ] If I move the map does a reset icon appears on top of zoom icons?
+- [ ] If I click the reset icon does it zoom back to UK and disappear?
+- [ ] On a browser without WebGL support, does a friendly "Map Unavailable" message show instead of an error?
+
+### Cloud Layer
+- [ ] Does a `Clouds` toggle button show on the map (PV Forecast view only, not on Delta View)?
+- [ ] Clicking `Clouds` shows the satellite imagery layer on the map?
+- [ ] Clicking `Clouds` again hides the satellite imagery layer?
+- [ ] When `Clouds` is enabled, does a channel dropdown appear with `Composites` and `Individual bands` groups?
+- [ ] Does a loading spinner show on the `Clouds` button while satellite imagery is fetching?
+- [ ] Does a `PV` toggle button show, to show/hide the yellow PV forecast overlay on the map?
+- [ ] Turning `Clouds` off automatically re-enables the `PV` overlay?
+- [ ] Scrubbing between nearby timesteps with `Clouds` on feels smooth, without a fresh loading spinner each time (prefetch/caching)?
+- [ ] If satellite imagery isn't available for the selected time (e.g. future timestep), does a friendly "unavailable" message show in place of the dropdown?
 
 
 ## Delta View
@@ -132,6 +146,18 @@
   - [ ] Does the Nhr forecast _not_ show on the legend, charts or tooltips when switched off?
   - [ ] Does the Nhr hours switcher _not_ show when toggled off?
 - [ ] Does the Nhr forecast toggle persist across refreshes/logouts using cookie?
+
+
+## P-level Settings
+
+- [ ] Does a `Settings` option show in the Profile Dropdown menu (top right)?
+- [ ] Clicking `Settings` opens a Settings modal with a "P-levels" section?
+- [ ] Are the P2/P98, P10/P90 and P25/P75 pairs each shown with their own toggle?
+- [ ] Toggling a P-level pair on adds its shading/line to the National & GSP charts?
+- [ ] Toggling a P-level pair off removes its shading/line from the charts?
+- [ ] Does the chart tooltip only show values for the currently-enabled P-level pairs?
+- [ ] Does the P-level selection persist across refreshes/logouts using cookie?
+- [ ] Does the CSV export only include columns for the currently-selected P-levels?
 
 
 ## Combined views


### PR DESCRIPTION
# Quartz UI Staging Release

## Overview

- Status banner now reads from the Status API's `/products` endpoint (spec v0.2.0) instead of the two data-API status routes with PR #780
  - "Is the service up?" is no longer answered by the same service being asked about, and it is no longer GB-only.
  - The banner stacks a labelled, dismissable row per affected product, sorted worst-first, replacing the single row picked by current view. `ok` is silent; `info` gets its own blue/ℹ️ treatment.
  - Dismissal is per-session and keyed on the incident's `updatedAt`, so an updated incident comes back on its own.
  - Product keys, labels and ordering live in `config/statusProducts.ts`, with entitlement behind one function. It returns every product for now, and locks down to the Auth0 `products` claim when the Europe UI ships.
- Status message handling and emoji display fixes with PR #773
  - Fixes issue #771
- Extended the ignored-errors list in Sentry with PR #778

> [!WARNING]
> `NEXT_PUBLIC_STATUS_URL` needs to be set in respective Preview/Prod environments. It degrades silently when unset  — no banner, no error, indistinguishable from all-clear — so a missing var will not announce itself. Worth confirming before sign-off.

## How Has This Been Tested?

- [ ] [Development](https://dev.quartz.solar)

Covered on the feature PRs: live `status-dev.quartz.energy` with `nl-solar` on `info`, all-three-`ok` (no banner), a stub serving `error`/`warning`/`info` at once, and an invented level falling back to `unknown`. Dismissal survives a reload and a re-poll.

Still to check on staging: that the status URL is set, and that a real incident renders end to end against the staging status service.

`yarn test` 118 passing, `tsc --noEmit` clean.

## Screenshots (if applicable)

_Attach: single labelled `info` row; stacked error/warning/info._

---


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made any corresponding changes to the README
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have bumped the version in `package.json` — still 0.7.4 on both branches, needs doing for this release
