### PR TITLE
perf(satellite): composite channels on backend and cache presigned urls 

### DIFF
--- a/apps/nowcasting-app/components/helpers/satelliteLayer.ts
+++ b/apps/nowcasting-app/components/helpers/satelliteLayer.ts
@@ -240,11 +240,49 @@ export async function fetchSatelliteTif(
   }
 }
 
+// Presigned URLs warmed from GET /satellite/history, keyed by `channel|timestamp`.
+const presignedUrlCache = new Map<string, string>();
+
+// Warm the cache for `channels` between startISO and endISO (inclusive), one
+// GET /satellite/history request per channel rather than one per timestep.
+export async function warmPresignedUrlHistory(
+  channels: SatelliteChannel[],
+  startISO: string,
+  endISO: string
+): Promise<void> {
+  const token = await getToken();
+  await Promise.all(
+    channels.map(async (channel) => {
+      const url = `${API_PREFIX}/satellite/history?channel=${encodeURIComponent(
+        channel
+      )}&start=${encodeURIComponent(startISO)}&end=${encodeURIComponent(endISO)}`;
+      const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+      if (!res.ok) return;
+      const entries: { timestamp: string; url: string }[] = await res.json();
+      // new Date(...).toISOString() matches the "Z"-suffixed keys used elsewhere,
+      // even if the backend serialises its timestamp with a "+00:00" offset.
+      entries.forEach((e) =>
+        presignedUrlCache.set(`${channel}|${new Date(e.timestamp).toISOString()}`, e.url)
+      );
+    })
+  );
+}
+
 async function requestSatelliteTif(
   channel: SatelliteChannel,
   timestamp: string,
   latest: boolean
 ): Promise<ArrayBuffer | null> {
+  const cacheKey = `${channel}|${timestamp}`;
+  const cachedUrl = !latest ? presignedUrlCache.get(cacheKey) : undefined;
+  if (cachedUrl) {
+    const s3Res = await fetch(cachedUrl);
+    if (s3Res.ok) return s3Res.arrayBuffer();
+    if (s3Res.status === 404) return null;
+    // Stale despite being warmed — drop it and fall through to a fresh request.
+    presignedUrlCache.delete(cacheKey);
+  }
+
   const token = await getToken();
   const apiUrl = `${API_PREFIX}/satellite/?channel=${encodeURIComponent(
     channel
@@ -272,6 +310,7 @@ async function requestSatelliteTif(
     const contentType = apiRes.headers.get("content-type") || "";
     if (contentType.includes("application/json")) {
       const { url } = await apiRes.json();
+      if (!latest) presignedUrlCache.set(cacheKey, url);
       const s3Res = await fetch(url);
       if (s3Res.status === 404) return null;
       if (!s3Res.ok) throw new Error(`S3 fetch failed: ${s3Res.status}`);

--- a/apps/nowcasting-app/components/helpers/satelliteLayer.ts
+++ b/apps/nowcasting-app/components/helpers/satelliteLayer.ts
@@ -11,7 +11,10 @@ export const SATELLITE_CHANNELS = [
   "IR_120",
   "IR_134",
   "WV_062",
-  "WV_073"
+  "WV_073",
+  "VISIBLE_COMPOSITE",
+  "INFRARED_COMPOSITE",
+  "WATER_VAPOUR_COMPOSITE"
 ] as const;
 export type SatelliteChannel = (typeof SATELLITE_CHANNELS)[number];
 
@@ -106,7 +109,10 @@ export const SATELLITE_CHANNEL_LABELS: Record<SatelliteChannel, string> = {
   IR_120: "Infrared 12.0µm",
   IR_134: "Infrared 13.4µm",
   WV_062: "Water Vapour 6.2µm",
-  WV_073: "Water Vapour 7.3µm"
+  WV_073: "Water Vapour 7.3µm",
+  VISIBLE_COMPOSITE: "Visible Composite - Backend Test",
+  INFRARED_COMPOSITE: "Infrared Composite - Backend Test",
+  WATER_VAPOUR_COMPOSITE: "Water Vapour Composite - Backend Test"
 };
 
 export type TifLayerData = {

--- a/apps/nowcasting-app/components/map/map.tsx
+++ b/apps/nowcasting-app/components/map/map.tsx
@@ -25,7 +25,8 @@ import {
   fetchAndDecodeSatelliteTif,
   applyTifLayerToMap,
   setVisibleSatelliteChannels,
-  orderSatelliteLayers
+  orderSatelliteLayers,
+  warmPresignedUrlHistory
 } from "../helpers/satelliteLayer";
 import { addMinutesToISODate } from "../helpers/utils";
 
@@ -295,6 +296,19 @@ const Map: FC<IMap> = ({
       if (refresh) clearInterval(refresh);
     };
   }, [selectedISOTime, activeChannel, isMapReady, showCloudLayer, timeNow, title]);
+
+  // Warm the presigned-URL cache for the whole scrubbable history, once per
+  // channel selection, so scrubbing back lands on a cached URL.
+  const historyWarmedForRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (title !== VIEWS.FORECAST || !isMapReady) return;
+    if (historyWarmedForRef.current === activeChannel) return;
+    historyWarmedForRef.current = activeChannel;
+
+    const anchor = get30MinNow();
+    const start = addMinutesToISODate(anchor, -2880);
+    warmPresignedUrlHistory(channelsForSelection(activeChannel), start, anchor);
+  }, [activeChannel, isMapReady, title]);
 
   // Keep the latest autoZoom value available inside Mapbox event handlers (avoid stale closures)
   const autozoomRef = useRef(autoZoom);


### PR DESCRIPTION
# Pull Request

## Description

add composite channels to backend and cache s3 presigned  URL's 


Fixes https://github.com/openclimatefix/quartz-api/pull/367

## How Has This Been Tested?

- [x] Locally
- [ ] https://nowcasting-app-git-perf-satelite-ui-composite-openclimatefix.vercel.app/

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
